### PR TITLE
Use New ZIO Error Handling Combinators

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/QueryFailure.scala
+++ b/zio-query/shared/src/main/scala/zio/query/QueryFailure.scala
@@ -1,7 +1,5 @@
 package zio.query
 
-import zio.Cause
-
 /**
  * `QueryFailure` keeps track of details relevant to query failures.
  */
@@ -9,35 +7,4 @@ final case class QueryFailure(dataSource: DataSource[Nothing, Nothing], request:
     extends Throwable(null, null, true, false) {
   override def getMessage: String =
     s"Data source ${dataSource.identifier} did not complete request ${request.toString}."
-}
-
-object QueryFailure {
-
-  /**
-   * Strips all query failures from the specified cause, returning either
-   * `None` is there are no causes other than query failures or a cause known
-   * to contain no query failures.
-   */
-  def strip[E](cause: Cause[E]): Option[Cause[E]] =
-    cause.fold(
-      None,
-      e => Some(Cause.Fail(e)), {
-        case _: QueryFailure => None
-        case t               => Some(Cause.Die(t))
-      },
-      fiberId => Some(Cause.Interrupt(fiberId))
-    )(
-      {
-        case (Some(l), Some(r)) => Some(Cause.Both(l, r))
-        case (Some(l), None)    => Some(l)
-        case (None, Some(r))    => Some(r)
-        case (None, None)       => None
-      }, {
-        case (Some(l), Some(r)) => Some(Cause.Then(l, r))
-        case (Some(l), None)    => Some(l)
-        case (None, Some(r))    => Some(r)
-        case (None, None)       => None
-      },
-      (causeOption, trace) => causeOption.map(Cause.Traced(_, trace))
-    )
 }

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -168,7 +168,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, Cache), Nothin
    */
   final def optional: ZQuery[R, E, Option[A]] =
     foldCauseM(
-      QueryFailure.strip(_).fold[ZQuery[R, E, Option[A]]](ZQuery.none)(ZQuery.halt(_)),
+      _.stripSomeDefects { case _: QueryFailure => () }.fold[ZQuery[R, E, Option[A]]](ZQuery.none)(ZQuery.halt(_)),
       ZQuery.some(_)
     )
 


### PR DESCRIPTION
We can use the new `stripSomeDefects` combinator from ZIO to avoid having to implement the logic for removing query failures from a cause ourselves.