### PR TITLE
Use Chunk In Definition Of DataSource

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -51,7 +51,7 @@ private[query] sealed trait BlockedRequests[-R] { self =>
       ZIO.foreachPar_(requestsByDataSource.toIterable) {
         case (dataSource, sequential) =>
           for {
-            completedRequests <- dataSource.runAll(sequential.map(_.map(_.request).toList).toList)
+            completedRequests <- dataSource.runAll(sequential.map(_.map(_.request)))
             _ <- ZIO.foreach_(sequential) { parallel =>
                   ZIO.foreach_(parallel) { blockedRequest =>
                     blockedRequest.result.set(completedRequests.lookup(blockedRequest.request))

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -5,7 +5,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{ after, nonFlaky, silent }
 import zio.test._
 import zio.test.environment.{ TestConsole, TestEnvironment }
-import zio.{ console, Has, Promise, Ref, ZIO, ZLayer }
+import zio.{ console, Chunk, Has, Promise, Ref, ZIO, ZLayer }
 
 object ZQuerySpec extends ZIOBaseSpec {
 
@@ -201,7 +201,7 @@ object ZQuerySpec extends ZIOBaseSpec {
             ref.get
           val identifier: String =
             "CacheDataSource"
-          def runAll(requests: Iterable[Iterable[CacheRequest[Any]]]): ZIO[Any, Nothing, CompletedRequestMap] =
+          def runAll(requests: Chunk[Chunk[CacheRequest[Any]]]): ZIO[Any, Nothing, CompletedRequestMap] =
             ref.update(requests.map(_.toSet).toList :: _) *>
               ZIO
                 .foreach(requests) { requests =>


### PR DESCRIPTION
Now that `Chunk` extends `Iterable`, we can change the signature of `DataSource` to:

```scala
def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap]
```

Since `Chunk` is a more specific type than `Iterable` this shouldn't require any changes to implementations of data sources unless you are extending `DataSource` directly (in which case you just have to update the signature) or you are using one of the "batched" variants (in which case you just have to return a `Chunk` instead of an `Iterable`).