### PR TITLE
Explore Alternative DataSourceAspect Encoding

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -40,7 +40,7 @@ trait DataSource[-R, -A] { self =>
   /**
    * Syntax for adding aspects.
    */
-  def @@[R1](aspect: DataSourceAspect[R, R1]): DataSource[R1, A] =
+  def @@[Out[+_]](aspect: DataSourceAspect.Aux[R, Out]): DataSource[Out[R], A] =
     aspect(self)
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -34,7 +34,7 @@ private[query] sealed trait BlockedRequests[-R] { self =>
    * can change the environment type of data sources but must preserve the
    * request type of each data source.
    */
-  final def mapDataSources[R1](f: DataSourceAspect[R, R1]): BlockedRequests[R1] =
+  final def mapDataSources[Out[+_]](f: DataSourceAspect.Aux[R, Out]): BlockedRequests[Out[R]] =
     self match {
       case Empty          => Empty
       case Both(l, r)     => Both(l.mapDataSources(f), r.mapDataSources(f))


### PR DESCRIPTION
As we work to add more functionality to data source aspects, one of the issues we run into is that the existing signature does not support everything we want to do. For example, currently if we want to write an `around` data source aspect we need to do something like:

```scala
  /**
   * A data source aspect that executes requests between two effects, `before`
   * and `after`, where the result of `before` can be used by `after`.
   */
  def around[R0, R, A0](
    before: Described[ZIO[R0, Nothing, A0]]
  )(after: Described[A0 => ZIO[R0, Nothing, Any]]): DataSourceAspect[R, R0 with R] =
    ???
```

The problem here is that the `R` parameter is completely unbound which will lead to type inference issues. More fundamentally, right now we are saying that this aspect for some specific `R` will return a new data source that requires that `R` plus the environment required by the effects, instead of that for any `R` it will do that.

This PR explores an encoding using path dependent types similar to the alternative encoding for test aspects we explored in December.

```scala
trait DataSourceAspect[+R] {
  type Out[+_]

  def apply[R1 >: R, A](dataSource: DataSource[R1, A]): DataSource[Out[R1], A]
}
```

Data source aspects become type level functions that can accept an environment that is not any more constrained than `R` and transform it in arbitrary ways. With this we can implement both `provide` and friends as well as data source aspects that add environmental requirements. This is potentially relevant to our exploration of test aspects, though I think the issue with test aspects is that we don't have union types so we can't express the union of two errors types the way we can express the intersection of two environment types with `with`.

The main disadvantage I see with this is that it significantly increases the complexity budget by requiring path dependent types and type lambdas in a way that is relatively user facing.

I think an alternative would be to move to a more traditional test aspect encoding and revert the `provide` variants to being part of a separate `DataSourceFunction` type that could potentially be package private or inlined entirely. This loses some conceptual unification but I think users will typically be providing environments at the `ZQuery` level so I don't think we will be losing much there and it could be significantly simpler.

I will open another PR based on that approach but thought this was interesting enough to share.