### PR TITLE
Move To Test Aspect Encoding

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -38,12 +38,6 @@ trait DataSource[-R, -A] { self =>
   def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap]
 
   /**
-   * Syntax for adding aspects.
-   */
-  def @@[R0 <: R1, R1 <: R](aspect: DataSourceAspect[R0, R1]): DataSource[R1, A] =
-    aspect(self)
-
-  /**
    * Returns a new data source that executes requests of type `B` using the
    * specified function to transform `B` requests into requests that this data
    * source can execute.

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -40,7 +40,7 @@ trait DataSource[-R, -A] { self =>
   /**
    * Syntax for adding aspects.
    */
-  def @@[R1](aspect: DataSourceAspect[R, R1]): DataSource[R1, A] =
+  def @@[R0 <: R1, R1 <: R](aspect: DataSourceAspect[R0, R1]): DataSource[R1, A] =
     aspect(self)
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -1,65 +1,40 @@
 package zio.query
 
-/**
- * A `DataSourceAspect[R, R1]` is a universally quantified function from
- * values of type `DataSource[R, A]` to values of type `DataSource[R1, A]` for
- * all types `A`. This is used internally by the library to describe functions
- * for transforming data sources that do not change the type of requests that a
- * data source is able to execute.
- */
-trait DataSourceAspect[+R, -R1] { self =>
+import zio.{ Chunk, ZIO }
 
-  def apply[A](dataSource: DataSource[R, A]): DataSource[R1, A]
+trait DataSourceAspect[+LowerR, -UpperR] { self =>
 
-  /**
-   * A symbolic alias for `compose`.
-   */
-  final def <<<[R0](that: DataSourceAspect[R0, R]): DataSourceAspect[R0, R1] =
-    self compose that
+  def apply[R >: LowerR <: UpperR, A](dataSource: DataSource[R, A]): DataSource[R, A]
 
-  /**
-   * A symbolic alias for `andThen`.
-   */
-  final def >>>[R2](that: DataSourceAspect[R1, R2]): DataSourceAspect[R, R2] =
-    self andThen that
+  def >>>[LowerR1 >: LowerR, UpperR1 <: UpperR](
+    that: DataSourceAspect[LowerR1, UpperR1]
+  ): DataSourceAspect[LowerR1, UpperR1] =
+    andThen(that)
 
-  /**
-   * Creates a new data source aspect by applying this data source aspect
-   * followed by that data source aspect.
-   */
-  final def andThen[R2](that: DataSourceAspect[R1, R2]): DataSourceAspect[R, R2] =
-    new DataSourceAspect[R, R2] {
-      def apply[A](dataSource: DataSource[R, A]): DataSource[R2, A] =
+  def andThen[LowerR1 >: LowerR, UpperR1 <: UpperR](
+    that: DataSourceAspect[LowerR1, UpperR1]
+  ): DataSourceAspect[LowerR1, UpperR1] =
+    new DataSourceAspect[LowerR1, UpperR1] {
+      def apply[R >: LowerR1 <: UpperR1, A](dataSource: DataSource[R, A]): DataSource[R, A] =
         that(self(dataSource))
-    }
-
-  /**
-   * Creates a new data source aspect by applying that data source aspect
-   * followed by this data source aspect.
-   */
-  final def compose[R0](that: DataSourceAspect[R0, R]): DataSourceAspect[R0, R1] =
-    new DataSourceAspect[R0, R1] {
-      def apply[A](dataSource: DataSource[R0, A]): DataSource[R1, A] =
-        self(that(dataSource))
     }
 }
 
 object DataSourceAspect {
 
   /**
-   * A data source aspect that provides a data source with its required
-   * environment.
+   * A data source aspect that executes requests between two effects, `before`
+   * and `after`, where the result of `before` can be used by `after`.
    */
-  def provide[R](r: Described[R]): DataSourceAspect[R, Any] =
-    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
-
-  /**
-   * A data source aspect that provides a data sources with part of its
-   * required environment.
-   */
-  def provideSome[R, R1](f: Described[R1 => R]): DataSourceAspect[R, R1] =
-    new DataSourceAspect[R, R1] {
-      def apply[A](dataSource: DataSource[R, A]): DataSource[R1, A] =
-        dataSource.provideSome(f)
+  def around[R0, A0](
+    before: Described[ZIO[R0, Nothing, A0]]
+  )(after: Described[A0 => ZIO[R0, Nothing, Any]]): DataSourceAspect[Nothing, R0] =
+    new DataSourceAspect[Nothing, R0] {
+      def apply[R <: R0, A](dataSource: DataSource[R, A]): DataSource[R, A] =
+        new DataSource[R, A] {
+          val identifier = s"${dataSource.identifier} @@ around(${before.description})(${after.description})"
+          def runAll(requests: Chunk[Chunk[A]]): ZIO[R, Nothing, CompletedRequestMap] =
+            before.value.bracket(after.value)(_ => runAll(requests))
+        }
     }
 }

--- a/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -17,14 +17,14 @@ trait DataSourceAspect[-R] { self =>
   /**
    * A symbolic alias for `andThen`.
    */
-  def >>>[R1 <: R](that: DataSourceAspect[R1]): DataSourceAspect[R1] =
+  final def >>>[R1 <: R](that: DataSourceAspect[R1]): DataSourceAspect[R1] =
     andThen(that)
 
   /**
    * Returns a new aspect that represents the sequential composition of this
    * aspect with the specified one.
    */
-  def andThen[R1 <: R](that: DataSourceAspect[R1]): DataSourceAspect[R1] =
+  final def andThen[R1 <: R](that: DataSourceAspect[R1]): DataSourceAspect[R1] =
     new DataSourceAspect[R1] {
       def apply[R2 <: R1, A](dataSource: DataSource[R2, A]): DataSource[R2, A] =
         that(self(dataSource))

--- a/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -10,7 +10,7 @@ import zio.{ Chunk, ZIO }
 trait DataSourceAspect[-R] { self =>
 
   /**
-   * Applies the aspect to some a data source.
+   * Applies the aspect to a data source.
    */
   def apply[R1 <: R, A](dataSource: DataSource[R1, A]): DataSource[R1, A]
 

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -43,6 +43,12 @@ import zio.query.internal.{ BlockedRequest, BlockedRequests, Continue, Result }
 final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, Cache), Nothing, Result[R, E, A]]) { self =>
 
   /**
+   * Syntax for adding aspects.
+   */
+  def @@[R1 <: R](aspect: DataSourceAspect[R1]): ZQuery[R1, E, A] =
+    mapDataSources(aspect)
+
+  /**
    * A symbolic alias for `zipParRight`.
    */
   final def &>[R1 <: R, E1 >: E, B](that: ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
@@ -161,6 +167,12 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, Cache), Nothin
    */
   final def map[B](f: A => B): ZQuery[R, E, B] =
     ZQuery(step.map(_.map(f)))
+
+  /**
+   * Transforms all data sources with the specified data source aspect.
+   */
+  def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): ZQuery[R1, E, A] =
+    ZQuery(step.map(_.mapDataSources(f)))
 
   /**
    * Maps the specified function over the failed result of this query.

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -45,7 +45,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, Cache), Nothin
   /**
    * Syntax for adding aspects.
    */
-  def @@[R1 <: R](aspect: DataSourceAspect[R1]): ZQuery[R1, E, A] =
+  final def @@[R1 <: R](aspect: DataSourceAspect[R1]): ZQuery[R1, E, A] =
     mapDataSources(aspect)
 
   /**
@@ -171,7 +171,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, Cache), Nothin
   /**
    * Transforms all data sources with the specified data source aspect.
    */
-  def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): ZQuery[R1, E, A] =
+  final def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): ZQuery[R1, E, A] =
     ZQuery(step.map(_.mapDataSources(f)))
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -34,7 +34,7 @@ private[query] sealed trait BlockedRequests[-R] { self =>
    * can change the environment type of data sources but must preserve the
    * request type of each data source.
    */
-  final def mapDataSources[R0 <: R1, R1 <: R](f: DataSourceAspect[R0, R1]): BlockedRequests[R1] =
+  final def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): BlockedRequests[R1] =
     self match {
       case Empty          => Empty
       case Both(l, r)     => Both(l.mapDataSources(f), r.mapDataSources(f))

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -42,6 +42,9 @@ private[query] sealed trait BlockedRequests[-R] { self =>
       case Single(ds, br) => Single(f(ds), br)
     }
 
+  /**
+   * Provides each data source with part of its required environment.
+   */
   final def provideSome[R0](f: Described[R0 => R]): BlockedRequests[R0] =
     self match {
       case Empty          => Empty

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 
 import zio.ZIO
 import zio.query.internal.BlockedRequests._
-import zio.query.{ DataSource, DataSourceAspect }
+import zio.query.{ DataSource, DataSourceAspect, Described }
 
 /**
  * `BlockedRequests` captures a collection of blocked requests as a data
@@ -34,12 +34,20 @@ private[query] sealed trait BlockedRequests[-R] { self =>
    * can change the environment type of data sources but must preserve the
    * request type of each data source.
    */
-  final def mapDataSources[R1](f: DataSourceAspect[R, R1]): BlockedRequests[R1] =
+  final def mapDataSources[R0 <: R1, R1 <: R](f: DataSourceAspect[R0, R1]): BlockedRequests[R1] =
     self match {
       case Empty          => Empty
       case Both(l, r)     => Both(l.mapDataSources(f), r.mapDataSources(f))
       case Then(l, r)     => Then(l.mapDataSources(f), r.mapDataSources(f))
       case Single(ds, br) => Single(f(ds), br)
+    }
+
+  final def provideSome[R0](f: Described[R0 => R]): BlockedRequests[R0] =
+    self match {
+      case Empty          => Empty
+      case Both(l, r)     => Both(l.provideSome(f), r.provideSome(f))
+      case Then(l, r)     => Then(l.provideSome(f), r.provideSome(f))
+      case Single(ds, br) => Single(ds.provideSome(f), br)
     }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -21,7 +21,7 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
   final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): Continue[R, Nothing, B] =
     self match {
       case Effect(query) => effect(query.fold(failure, success))
-      case Get(io)    => get(io.fold(failure, success))
+      case Get(io)       => get(io.fold(failure, success))
 
     }
 

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -20,8 +20,9 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
    */
   final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): Continue[R, Nothing, B] =
     self match {
-      case Get(query)    => get(query.fold(failure, success))
       case Effect(query) => effect(query.fold(failure, success))
+      case Get(io)    => get(io.fold(failure, success))
+
     }
 
   /**
@@ -32,26 +33,28 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
     success: A => ZQuery[R1, E1, B]
   ): Continue[R1, E1, B] =
     self match {
-      case Get(io)       => effect(ZQuery.fromEffect(io).foldCauseM(failure, success))
       case Effect(query) => effect(query.foldCauseM(failure, success))
+      case Get(io)       => effect(ZQuery.fromEffect(io).foldCauseM(failure, success))
     }
 
   /**
    * Purely maps over the success type of this continuation.
    */
-  def map[B](f: A => B): Continue[R, E, B] =
+  final def map[B](f: A => B): Continue[R, E, B] =
     self match {
-      case Get(io)       => get(io.map(f))
       case Effect(query) => effect(query.map(f))
+      case Get(io)       => get(io.map(f))
+
     }
 
   /**
    * Transforms all data sources with the specified data source aspect.
    */
-  def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): Continue[R1, E, A] =
+  final def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): Continue[R1, E, A] =
     self match {
-      case Get(io)       => get(io)
       case Effect(query) => effect(query.mapDataSources(f))
+      case Get(io)       => get(io)
+
     }
 
   /**
@@ -59,59 +62,61 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
    */
   final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): Continue[R, E1, A] =
     self match {
-      case Get(io)       => get(io.mapError(f))
       case Effect(query) => effect(query.mapError(f))
+      case Get(io)       => get(io.mapError(f))
+
     }
 
   /**
    * Effectually maps over the success type of this continuation.
    */
-  def mapM[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B]): Continue[R1, E1, B] =
+  final def mapM[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B]): Continue[R1, E1, B] =
     self match {
-      case Get(io)       => effect(ZQuery.fromEffect(io).flatMap(f))
       case Effect(query) => effect(query.flatMap(f))
+      case Get(io)       => effect(ZQuery.fromEffect(io).flatMap(f))
     }
 
   /**
    * Purely contramaps over the environment type of this continuation.
    */
-  def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): Continue[R0, E, A] =
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): Continue[R0, E, A] =
     self match {
-      case Get(io)       => get(io)
       case Effect(query) => effect(query.provideSome(f))
+      case Get(io)       => get(io)
+
     }
 
   /**
    * Runs this continuation..
    */
-  def runCache(cache: Cache): ZIO[R, E, A] =
+  final def runCache(cache: Cache): ZIO[R, E, A] =
     self match {
-      case Get(io)       => io
       case Effect(query) => query.runCache(cache)
+      case Get(io)       => io
     }
 
   /**
    * Combines this continuation with that continuation using the specified
    * function, in sequence.
    */
-  def zipWith[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
+  final def zipWith[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
     (self, that) match {
-      case (Get(l), Get(r))       => get(l.zipWith(r)(f))
-      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWith(r)(f))
-      case (Effect(l), Get(r))    => effect(l.zipWith(ZQuery.fromEffect(r))(f))
       case (Effect(l), Effect(r)) => effect(l.zipWith(r)(f))
+      case (Effect(l), Get(r))    => effect(l.zipWith(ZQuery.fromEffect(r))(f))
+      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWith(r)(f))
+      case (Get(l), Get(r))       => get(l.zipWith(r)(f))
     }
 
   /**
    * Combines this continuation with that continuation using the specified
    * function, in parallel.
    */
-  def zipWithPar[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
+  final def zipWithPar[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
     (self, that) match {
-      case (Get(l), Get(r))       => get(l.zipWithPar(r)(f))
-      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWithPar(r)(f))
-      case (Effect(l), Get(r))    => effect(l.zipWithPar(ZQuery.fromEffect(r))(f))
       case (Effect(l), Effect(r)) => effect(l.zipWithPar(r)(f))
+      case (Effect(l), Get(r))    => effect(l.zipWithPar(ZQuery.fromEffect(r))(f))
+      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWithPar(r)(f))
+      case (Get(l), Get(r))       => get(l.zipWithPar(r)(f))
     }
 
 }

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -1,7 +1,7 @@
 package zio.query.internal
 
+import zio.query._
 import zio.query.internal.Continue._
-import zio.query.{ Cache, DataSource, Described, QueryFailure, Request, ZQuery }
 import zio.{ CanFail, Cause, IO, NeedsEnv, Ref, ZIO }
 
 /**
@@ -43,6 +43,15 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
     self match {
       case Get(io)       => get(io.map(f))
       case Effect(query) => effect(query.map(f))
+    }
+
+  /**
+   * Transforms all data sources with the specified data source aspect.
+   */
+  def mapDataSources[R1 <: R](f: DataSourceAspect[R1]): Continue[R1, E, A] =
+    self match {
+      case Get(io)       => get(io)
+      case Effect(query) => effect(query.mapDataSources(f))
     }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -1,7 +1,7 @@
 package zio.query.internal
 
 import zio.query.internal.Result._
-import zio.query.{ DataSourceAspect, Described }
+import zio.query.Described
 import zio.{ CanFail, Cause, NeedsEnv }
 
 /**
@@ -52,7 +52,7 @@ private[query] sealed trait Result[-R, +E, +A] { self =>
    */
   final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): Result[R0, E, A] =
     self match {
-      case Blocked(br, c) => blocked(br.mapDataSources(DataSourceAspect.provideSome(f)), c.provideSome(f))
+      case Blocked(br, c) => blocked(br.provideSome(f), c.provideSome(f))
       case Done(a)        => done(a)
       case Fail(e)        => fail(e)
     }


### PR DESCRIPTION
Moves data source aspect encoding to a more traditional test aspect encoding. Relative to #40 we lose the ability to eliminate environmental requirements with data source aspects the implementation is significantly simpler. I think this is the way to go though open to feedback from others.