### PR TITLE
Implement QueryContext

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/internal/QueryContext.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/QueryContext.scala
@@ -1,0 +1,11 @@
+package zio.query.internal
+
+import zio.query.Cache
+
+/**
+ * `QueryContext` maintains the context of a query. Currently `QueryContext`
+ * simply maintains a `Cache` of requests and results but this will be
+ * augmented with other functionality such as logging and metrics in the
+ * future.
+ */
+private[query] final case class QueryContext(cache: Cache)


### PR DESCRIPTION
Changes signature of `ZQuery` to maintain ` QueryContext` instead of a `Cache` internally. Currently the `QueryContext` just contains the `Cache` but this will let us add other things like logging and metrics. No changes to user facing API.