### PR TITLE
Implement DataSource#race

### DIFF
--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -120,7 +120,14 @@ object ZQuerySpec extends ZIOBaseSpec {
           }
           .run
         assertM(effect)(equalTo(705082704))
-      } @@ TestAspect.ignore
+      } @@ TestAspect.ignore,
+      testM("data sources can be raced") {
+        for {
+          promise <- Promise.make[Nothing, Unit]
+          _       <- raceQuery(promise).run
+          _       <- promise.await
+        } yield assertCompletes
+      }
     ) @@ silent
 
   val userIds: List[Int]          = (1 to 26).toList
@@ -158,11 +165,8 @@ object ZQuerySpec extends ZIOBaseSpec {
 
   case object NeverRequest extends Request[Nothing, Nothing]
 
-  val neverDataSource: DataSource[Any, NeverRequest.type] =
-    DataSource.fromFunctionM("never")(_ => ZIO.never)
-
   val neverQuery: ZQuery[Any, Nothing, Nothing] =
-    ZQuery.fromRequest(NeverRequest)(neverDataSource)
+    ZQuery.fromRequest(NeverRequest)(DataSource.never)
 
   final case class SucceedRequest(promise: Promise[Nothing, Unit]) extends Request[Nothing, Unit]
 
@@ -173,6 +177,12 @@ object ZQuerySpec extends ZIOBaseSpec {
 
   def succeedQuery(promise: Promise[Nothing, Unit]): ZQuery[Any, Nothing, Unit] =
     ZQuery.fromRequest(SucceedRequest(promise))(succeedDataSource)
+
+  val raceDataSource: DataSource[Any, SucceedRequest] =
+    DataSource.never.race(succeedDataSource)
+
+  def raceQuery(promise: Promise[Nothing, Unit]): ZQuery[Any, Nothing, Unit] =
+    ZQuery.fromRequest(SucceedRequest(promise))(raceDataSource)
 
   sealed trait CacheRequest[+A] extends Request[Nothing, A]
 


### PR DESCRIPTION
Allows you to combine two data sources to create a new data source that will submit requests to both data sources and return results from the first one to complete.