### PR TITLE
Support Maximum Batch Size

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -48,4 +48,14 @@ object DataSourceAspect {
             before.value.bracket(after.value)(_ => runAll(requests))
         }
     }
+
+  /**
+   * A data source aspect that limits data sources to executing at most `n`
+   * requests in parallel.
+   */
+  def maxBatchSize(n: Int): DataSourceAspect[Any] =
+    new DataSourceAspect[Any] {
+      def apply[R, A](dataSource: DataSource[R, A]): DataSource[R, A] =
+        dataSource.batchN(n)
+    }
 }

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -1,6 +1,7 @@
 package zio.query
 
 import zio.console.Console
+import zio.query.DataSourceAspect._
 import zio.test.Assertion._
 import zio.test.TestAspect.{ after, nonFlaky, silent }
 import zio.test._
@@ -120,7 +121,15 @@ object ZQuerySpec extends ZIOBaseSpec {
           }
           .run
         assertM(effect)(equalTo(705082704))
-      } @@ TestAspect.ignore
+      } @@ TestAspect.ignore,
+      testM("max batch size") {
+        val query = getAllUserNames @@ maxBatchSize(3)
+        for {
+          result <- query.run
+          log    <- TestConsole.output
+        } yield assert(result)(hasSameElements(userNames.values)) &&
+          assert(log)(hasSize(equalTo(10)))
+      }
     ) @@ silent
 
   val userIds: List[Int]          = (1 to 26).toList


### PR DESCRIPTION
Adds a `batchN` combinator on data sources that limits them to executing at most `n` requests in parallel and a `maxBatchSize` data source aspect to let you apply it to an existing query like this:

```scala
getAllUserNames @@ maxBatchSize(100)
```

Resolves #46.