### PR TITLE
Fix ZQuery#collectAllPar for multiple data sources

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/internal/Parallel.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Parallel.scala
@@ -19,7 +19,7 @@ private[query] final class Parallel[-R](private val map: Map[DataSource[Any, Any
     new Parallel(
       self.map.foldLeft(that.map) {
         case (map, (k, v)) =>
-          map + (k -> map.get(k).fold[Chunk[BlockedRequest[Any]]](Chunk.empty)(_ ++ v))
+          map + (k -> map.get(k).fold[Chunk[BlockedRequest[Any]]](v)(_ ++ v))
       }
     )
 


### PR DESCRIPTION
Fixes a bug where it wasn't possible to use ZQuery#collectAllPar on queries from multiple data sources. 