### PR TITLE
Improve Performance Of Parallel Operations

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -114,9 +114,9 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
   final def zipWithPar[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
     (self, that) match {
       case (Effect(l), Effect(r)) => effect(l.zipWithPar(r)(f))
-      case (Effect(l), Get(r))    => effect(l.zipWithPar(ZQuery.fromEffect(r))(f))
-      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWithPar(r)(f))
-      case (Get(l), Get(r))       => get(l.zipWithPar(r)(f))
+      case (Effect(l), Get(r))    => effect(l.zipWith(ZQuery.fromEffect(r))(f))
+      case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWith(r)(f))
+      case (Get(l), Get(r))       => get(l.zipWith(r)(f))
     }
 
 }


### PR DESCRIPTION
A couple of optimizations to improve performance of parallel operations.

First, in `foreachPar` and `collectAllPar` we can do one fewer query by creating the builder for the new collection as part of one of the existing queries instead of creating a new query to do that.

Second, in the continuation of `zipWithPar` when one of the continuations just gets a value that has already been set in a `Ref` and applies a pure transformation to it we don't need to get `ZIO#zipWithPar` to combine the continuations since there is no need to apply parallelism to the pure computation.

With these changes the benchmarks in ghostdogpr/caliban#577 go from:

```
[info] Benchmark                                            Mode  Cnt      Score      Error  Units
[info] GraphQLBenchmarks.simpleCalibanWithZIOField10k      thrpt    5      8.233 ±    0.283  ops/s
[info] GraphQLBenchmarks.simpleCalibanWithZQueryField10k   thrpt    5      8.421 ±    0.968  ops/s
```

to:

```
[info] Benchmark                                            Mode  Cnt      Score     Error  Units
[info] GraphQLBenchmarks.simpleCalibanWithZIOField10k      thrpt    5     11.718 ±   0.142  ops/s
[info] GraphQLBenchmarks.simpleCalibanWithZQueryField10k   thrpt    5     12.158 ±   0.582  ops/s
```