### PR TITLE
Allow Data Sources To Return Additional Results

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -15,6 +15,12 @@ final class CompletedRequestMap private (private val map: Map[Any, Either[Any, A
     new CompletedRequestMap(self.map ++ that.map)
 
   /**
+   * Returns whether a result exists for the specified request.
+   */
+  def contains(request: Any): Boolean =
+    map.contains(request)
+
+  /**
    * Appends the specified result to the completed requests map.
    */
   def insert[E, A](request: Request[E, A])(result: Either[E, A]): CompletedRequestMap =
@@ -35,6 +41,12 @@ final class CompletedRequestMap private (private val map: Map[Any, Either[Any, A
    */
   def lookup[E, A](request: Request[E, A]): Option[Either[E, A]] =
     map.get(request).asInstanceOf[Option[Either[E, A]]]
+
+  /**
+   * Collects all requests in a set.
+   */
+  def requests: Set[Request[Any, Any]] =
+    map.keySet.asInstanceOf[Set[Request[Any, Any]]]
 }
 
 object CompletedRequestMap {

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -258,7 +258,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, QueryContext),
    */
   final def runCache(cache: Cache): ZIO[R, E, A] =
     step.provideSome[R]((_, QueryContext(cache))).flatMap {
-      case Result.Blocked(br, c) => br.run *> c.runCache(cache)
+      case Result.Blocked(br, c) => br.run(cache) *> c.runCache(cache)
       case Result.Done(a)        => ZIO.succeedNow(a)
       case Result.Fail(e)        => ZIO.halt(e)
     }


### PR DESCRIPTION
Sometimes in the process of of returning a result for one request, a data source inevitably computes results for other requests. For example, if a data source completes a request for getting all user names it already has the information to return the user name for any specific user.

This PR allows data sources to insert additional results into the `CompletedRequestMap` in cases like this. These results will then be available to subsequent steps of the query.

Thanks to @vigoo for raising the original problem.