### PR TITLE
Explore Callback Based Internal Representation for ZQuery

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSourceAspect.scala
@@ -50,6 +50,15 @@ object DataSourceAspect {
     }
 
   /**
+   * A data source aspect that returns data sources unchanged.
+   */
+  val identity: DataSourceAspect[Any] =
+    new DataSourceAspect[Any] {
+      def apply[R, A](dataSource: DataSource[R, A]): DataSource[R, A] =
+        dataSource
+    }
+
+  /**
    * A data source aspect that limits data sources to executing at most `n`
    * requests in parallel.
    */

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -140,8 +140,15 @@ final class ZQuery[-R, +E, +A] private (
     foldM(e => ZQuery.succeed(failure(e)), a => ZQuery.succeed(success(a)))
 
   /**
+   * A more powerful version of `fold` that allows recovering from any kind of
+   * failure.
+   */
+  final def foldCause[B](failure: Cause[E] => B, success: A => B): ZQuery[R, Nothing, B] =
+    foldCauseM(e => ZQuery.succeed(failure(e)), a => ZQuery.succeed(success(a)))
+
+  /**
    * A more powerful version of `foldM` that allows recovering from any type
-   * of failure except interruptions.
+   * of failure.
    */
   final def foldCauseM[R1 <: R, E1, B](
     failure: Cause[E] => ZQuery[R1, E1, B],

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -576,7 +576,7 @@ object ZQuery {
     request: A
   )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
     ZQuery { cb =>
-      ZIO.accessM[(R, QueryContext)] { case (r, queryContext) =>
+      ZIO.accessM[(R, QueryContext)] { case (_, queryContext) =>
         queryContext.cache.lookup(request).flatMap {
           case Left(ref) =>
             cb {

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -2,7 +2,7 @@ package zio.query.internal
 
 import zio.query._
 import zio.query.internal.Continue._
-import zio.{ CanFail, Cause, IO, NeedsEnv, Ref, ZIO }
+import zio._
 
 /**
  * A `Continue[R, E, A]` models a continuation of a blocked request that
@@ -87,12 +87,12 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
     }
 
   /**
-   * Runs this continuation..
+   * Runs this continuation with the specified callback.
    */
-  final def runCache(cache: Cache): ZIO[R, E, A] =
+  final def runCacheWith(cache: Cache)(cb: Exit[E, A] => UIO[Any]): URIO[R, Any] =
     self match {
-      case Effect(query) => query.runCache(cache)
-      case Get(io)       => io
+      case Effect(query) => query.runCacheWith(cache)(cb)
+      case Get(io)       => io.run.flatMap(cb)
     }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -87,11 +87,11 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
     }
 
   /**
-   * Runs this continuation with the specified callback.
+   * Runs this continuation..
    */
-  final def runCacheWith(cache: Cache)(cb: Exit[E, A] => UIO[Any]): URIO[R, Any] =
+  final def runAsync(cache: Cache)(cb: Exit[E, A] => UIO[Any]): URIO[R, Any] =
     self match {
-      case Effect(query) => query.runCacheWith(cache)(cb)
+      case Effect(query) => query.runAsync(cache)(cb)
       case Get(io)       => io.run.flatMap(cb)
     }
 

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -1,8 +1,8 @@
 package zio.query.internal
 
+import zio._
 import zio.query._
 import zio.query.internal.Continue._
-import zio._
 
 /**
  * A `Continue[R, E, A]` models a continuation of a blocked request that

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -68,9 +68,9 @@ private[query] sealed trait Result[-R, +E, +A] { self =>
     }
 
   /**
-    * Zips this result with that result in parallel using the specified
-    * function.
-    */
+   * Zips this result with that result in parallel using the specified
+   * function.
+   */
   final def zipWithPar[R1 <: R, E1 >: E, B, C](that: Result[R1, E1, B])(f: (A, B) => C): Result[R1, E1, C] =
     (self, that) match {
       case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) => Result.blocked(br1 && br2, c1.zipWithPar(c2)(f))

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -67,6 +67,10 @@ private[query] sealed trait Result[-R, +E, +A] { self =>
       case Fail(e)        => fail(e)
     }
 
+  /**
+    * Zips this result with that result in parallel using the specified
+    * function.
+    */
   final def zipWithPar[R1 <: R, E1 >: E, B, C](that: Result[R1, E1, B])(f: (A, B) => C): Result[R1, E1, C] =
     (self, that) match {
       case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) => Result.blocked(br1 && br2, c1.zipWithPar(c2)(f))

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -100,18 +100,6 @@ private[query] object Result {
   def fail[E](cause: Cause[E]): Result[Any, E, Nothing] =
     Fail(cause)
 
-  def reduceAllPar[R, E, A](as: List[Result[R, E, A]]): Result[R, E, List[A]] =
-    as.init.foldRight(as.last.map(List(_))) {
-      case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) =>
-        Result.blocked(br1 && br2, c1.zipWithPar(c2)(_ :: _))
-      case (Result.Blocked(br, c), Result.Done(b)) => Result.blocked(br, c.map(a => a :: b))
-      case (Result.Done(a), Result.Blocked(br, c)) => Result.blocked(br, c.map(b => a :: b))
-      case (Result.Done(a), Result.Done(b))        => Result.done(a :: b)
-      case (Result.Fail(e1), Result.Fail(e2))      => Result.fail(Cause.Both(e1, e2))
-      case (Result.Fail(e), _)                     => Result.fail(e)
-      case (_, Result.Fail(e))                     => Result.fail(e)
-    }
-
   /**
    * Lifts an `Either` into a result.
    */

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -89,6 +89,18 @@ private[query] object Result {
   def fail[E](cause: Cause[E]): Result[Any, E, Nothing] =
     Fail(cause)
 
+  def reduceAllPar[R, E, A](as: List[Result[R, E, A]]): Result[R, E, List[A]] =
+    as.init.foldRight(as.last.map(List(_))) {
+      case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) =>
+        Result.blocked(br1 && br2, c1.zipWithPar(c2)(_ :: _))
+      case (Result.Blocked(br, c), Result.Done(b)) => Result.blocked(br, c.map(a => a :: b))
+      case (Result.Done(a), Result.Blocked(br, c)) => Result.blocked(br, c.map(b => a :: b))
+      case (Result.Done(a), Result.Done(b))        => Result.done(a :: b)
+      case (Result.Fail(e1), Result.Fail(e2))      => Result.fail(Cause.Both(e1, e2))
+      case (Result.Fail(e), _)                     => Result.fail(e)
+      case (_, Result.Fail(e))                     => Result.fail(e)
+    }
+
   /**
    * Lifts an `Either` into a result.
    */


### PR DESCRIPTION
This PR explores a change to the internal encoding of `ZQuery` to a callback based one:

```scala
final class ZQuery[-R, +E, +A] private (
  private val start: (Result[R, E, A] => UIO[Any]) => ZIO[(R, QueryContext), Nothing, Any]
)
```

This lets us address the issue in ghostdogpr/caliban#577 where we were incurring additional overhead for forking queries that did not actually involve effects in `zipWithPar`. In this encoding, a query can either call the callback synchronously or asynchronously, so we can push the forking into the `fromEffect` constructor and avoid forking when the query is not actually effectual.