### PR TITLE
Implement Additional Parallelism Operators

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -598,8 +598,8 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, QueryContext),
   /**
    * Returns a query that models the execution of this query and the specified
    * query in parallel, combining their results with the specified function.
-   * Requests composed with `zipWithPar` or combinators derived from it will
-   * automatically be batched.
+   * Requests composed with `zipWithParQuery` or combinators derived from it
+   * will automatically be batched.
    *
    * Unlike `zipWithPar`, `zipwithParQuery` will not perform arbitrary effects
    * in parallel but will only batch requests to data sources. If you do not

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -918,8 +918,7 @@ object ZQuery {
       val chunk = ChunkBuilder.make[A]
       var j     = 0
       while (j <= quotient) {
-        val a = iterator.next()
-        chunk += a
+        chunk += iterator.next()
         j += 1
       }
       chunks += chunk.result()
@@ -930,8 +929,7 @@ object ZQuery {
         val chunk = ChunkBuilder.make[A]()
         var j     = 0
         while (j < quotient) {
-          val a = iterator.next()
-          chunk += a
+          chunk += iterator.next()
           j += 1
         }
         chunks += chunk.result()

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -609,7 +609,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[(R, QueryContext),
   final def zipWithParQuery[R1 <: R, E1 >: E, B, C](that: ZQuery[R1, E1, B])(f: (A, B) => C): ZQuery[R1, E1, C] =
     ZQuery {
       self.step.zipWith(that.step) {
-        case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) => Result.blocked(br1 && br2, c1.zipWithPar(c2)(f))
+        case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) => Result.blocked(br1 && br2, c1.zipWithParQuery(c2)(f))
         case (Result.Blocked(br, c), Result.Done(b))            => Result.blocked(br, c.map(a => f(a, b)))
         case (Result.Done(a), Result.Blocked(br, c))            => Result.blocked(br, c.map(b => f(a, b)))
         case (Result.Done(a), Result.Done(b))                   => Result.done(f(a, b))

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -121,16 +121,11 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
 
   /**
    * Combines this continuation with that continuation using the specified
-   * function, in parallel.
-   *
-   * Unlike `zipWithPar`, `zipWithParQuery` will not perform arbitrary effects
-   * in parallel but will only batch requests to data sources. If you do not
-   * need to perform arbitrary effects in parallel this can be significantly
-   * more efficient.
+   * function, batching requests to data sources.
    */
-  final def zipWithParQuery[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
+  final def zipWithBatched[R1 <: R, E1 >: E, B, C](that: Continue[R1, E1, B])(f: (A, B) => C): Continue[R1, E1, C] =
     (self, that) match {
-      case (Effect(l), Effect(r)) => effect(l.zipWithParQuery(r)(f))
+      case (Effect(l), Effect(r)) => effect(l.zipWithBatched(r)(f))
       case (Effect(l), Get(r))    => effect(l.zipWith(ZQuery.fromEffect(r))(f))
       case (Get(l), Effect(r))    => effect(ZQuery.fromEffect(l).zipWith(r)(f))
       case (Get(l), Get(r))       => get(l.zipWith(r)(f))

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -108,6 +108,18 @@ object ZQuerySpec extends ZIOBaseSpec {
           } yield assert(result)(equalTo(List(2, 1)))
         } @@ nonFlaky
       ),
+      suite("foreachBatchedPar")(
+        testM("identity") {
+          val smallInts = Gen.small(n => Gen.const(n), 1)
+          val chunks    = Gen.chunkOf(smallInts)
+          checkM(smallInts, chunks) { (n, chunk) =>
+            for {
+              left  <- ZQuery.foreachBatchedParN(n)(chunk)(ZQuery.succeed(_)).run
+              right <- ZQuery.foreach(chunk)(ZQuery.succeed(_)).run
+            } yield assert(left)(equalTo(right))
+          }
+        }
+      ),
       suite("zipPar")(
         testM("queries to multiple data sources can be executed in parallel") {
           for {

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -108,18 +108,6 @@ object ZQuerySpec extends ZIOBaseSpec {
           } yield assert(result)(equalTo(List(2, 1)))
         } @@ nonFlaky
       ),
-      suite("foreachBatchedPar")(
-        testM("identity") {
-          val smallInts = Gen.small(n => Gen.const(n), 1)
-          val chunks    = Gen.chunkOf(smallInts)
-          checkM(smallInts, chunks) { (n, chunk) =>
-            for {
-              left  <- ZQuery.foreachBatchedParN(n)(chunk)(ZQuery.succeed(_)).run
-              right <- ZQuery.foreach(chunk)(ZQuery.succeed(_)).run
-            } yield assert(left)(equalTo(right))
-          }
-        }
-      ),
       suite("zipPar")(
         testM("queries to multiple data sources can be executed in parallel") {
           for {


### PR DESCRIPTION
With `ZQuery` we have two potential forms of parallelism:

1. Executing requests to data sources in parallel by batching them
2. Performing arbitrary effects in parallel by forking them

Currently, parallel requests to data sources that only use the first form of parallelism are being slowed down because we do not have a way to statically "know" that a query did not perform arbitrary effects and thus did not need to be forked.

In #130 I explored an alternative callback based encoding of `ZQuery` to avoid this but the implementation of that required us to fork at least one fiber for each arbitrary effect which slowed down other use cases.

In this PR I am adding a new set of operators that do the first form of parallelism but not the second. This allows users who want to optimize their queries to take advantage of batching without the parallelism of forking arbitrary effects when they know they don't need to perform arbitrary effects in parallel.

Currently I am naming these operators with the `Query` suffix, so for example `zipWithParQuery` is like `zipWithPar` except that it performs requests to data sources in parallel without performing arbitrary effects in parallel.

I think having some version of these operators makes sense because there are two conceptually different forms of parallelism that users should be able to control but open to feedback on the API. I was also thinking of `zipWithBatched` to indicate batching but not parallelism.