### PR TITLE
Cross-build to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val zioQuery = crossProject(JSPlatform, JVMPlatform)
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
 
 lazy val zioQueryJS = zioQuery.js
+  .settings(dottySettings)
   .settings(scalaJSUseMainModuleInitializer := true)
 
 lazy val zioQueryJVM = zioQuery.jvm


### PR DESCRIPTION
I'd like to upgrade a project I'm working on to Scala 3 and saw that there's no artifact for Scala3-JS.
I went ahead and checked if cross-building works for Scala 3 and JS, and it actually does! 🎉 
Is there anything I'm overlooking, or is it as easy as that?