### PR TITLE
Optimize ZQuery.collectAllPar For Very Small Collections

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1120,9 +1120,12 @@ object ZQuery {
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
     ZQuery.suspend {
       val size = as.size
-      if (size == 0) ZQuery.succeed(bf.newBuilder(as).result())
-      else if (size == 1) f(as.head).map(bf.newBuilder(as) += _).map(_.result())
-      else ZQuery(ZIO.foreachPar(Chunk.fromIterable(as))(f(_).step).map(Result.collectAllPar(_).map(bf.fromSpecific(as))))
+      if (size == 0)
+        ZQuery.succeed(bf.newBuilder(as).result())
+      else if (size == 1)
+        f(as.head).map(bf.newBuilder(as) += _).map(_.result())
+      else
+        ZQuery(ZIO.foreachPar(Chunk.fromIterable(as))(f(_).step).map(Result.collectAllPar(_).map(bf.fromSpecific(as))))
     }
 
   /**


### PR DESCRIPTION
If the collection only has a single element we don't need to spin up any concurrency machinery.