### PR TITLE
Implement ZQuery#withParallelism

### DIFF
--- a/benchmarks/src/main/scala/zio/query/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/query/BenchmarkUtil.scala
@@ -1,0 +1,14 @@
+package zio.query
+
+import zio._
+
+object BenchmarkUtil extends Runtime[Any] { self =>
+  val environment = Runtime.default.environment
+
+  val fiberRefs = Runtime.default.fiberRefs
+
+  val runtimeFlags = Runtime.default.runtimeFlags
+
+  def unsafeRun[E, A](query: ZQuery[Any, E, A]): A =
+    Unsafe.unsafe(implicit unsafe => self.unsafe.run(query.run).getOrThrowFiberFailure())
+}

--- a/benchmarks/src/main/scala/zio/query/CollectAllBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/query/CollectAllBenchmark.scala
@@ -1,0 +1,49 @@
+package zio.query
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.query.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@Threads(1)
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class CollectAllBenchmark {
+
+  @Param(Array("100", "1000"))
+  var count: Int = 100
+
+  val parallelism: Int = 10
+
+  @Benchmark
+  def zQueryCollectAll(): Long = {
+    val queries  = (0 until count).map(_ => ZQuery.succeed(1)).toList
+    val query = ZQuery.collectAll(queries).map(_.sum.toLong)
+    unsafeRun(query)
+  }
+
+  @Benchmark
+  def zQueryCollectAllBatched(): Long = {
+    val queries  = (0 until count).map(_ => ZQuery.succeed(1)).toList
+    val query = ZQuery.collectAllBatched(queries).map(_.sum.toLong)
+    unsafeRun(query)
+  }
+
+  @Benchmark
+  def zQueryCollectAllPar(): Long = {
+    val queries  = (0 until count).map(_ => ZQuery.succeed(1)).toList
+    val query = ZQuery.collectAllPar(queries).map(_.sum.toLong)
+    unsafeRun(query)
+  }
+
+  @Benchmark
+  def zQueryCollectAllParN(): Long = {
+    val queries  = (0 until count).map(_ => ZQuery.succeed(1)).toList
+    val query = ZQuery.collectAllPar(queries).map(_.sum.toLong).withParallelism(parallelism)
+    unsafeRun(query)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,11 @@ lazy val zioQueryJS = zioQuery.js
 lazy val zioQueryJVM = zioQuery.jvm
   .settings(dottySettings)
 
+lazy val benchmarks = project.module
+  .in(file("benchmarks"))
+  .dependsOn(zioQueryJVM)
+  .enablePlugins(JmhPlugin)
+
 lazy val docs = project
   .in(file("zio-query-docs"))
   .settings(


### PR DESCRIPTION
Supports running queries with bounded parallelism. This can be significantly more efficient than unbounded parallelism.