### PR TITLE
Fix query inference

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1452,18 +1452,18 @@ object ZQuery {
       service[R].map(f)
   }
 
-  final class ServiceWithQueryPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](
-      f: R => ZQuery[R, E, A]
-    )(implicit tag: Tag[R], race: Trace): ZQuery[R, E, A] =
-      service[R].flatMap(f)
+  final class ServiceWithQueryPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[R <: Service, E, A](
+      f: Service => ZQuery[R, E, A]
+    )(implicit tag: Tag[Service], race: Trace): ZQuery[R with Service, E, A] =
+      service[Service].flatMap(f)
   }
 
-  final class ServiceWithZIOPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](
-      f: R => ZIO[R, E, A]
-    )(implicit tag: Tag[R], trace: Trace): ZQuery[R, E, A] =
-      service[R].mapZIO(f)
+  final class ServiceWithZIOPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
+    def apply[R <: Service, E, A](
+      f: Service => ZIO[R, E, A]
+    )(implicit tag: Tag[Service], trace: Trace): ZQuery[R with Service, E, A] =
+      service[Service].mapZIO(f)
   }
 
   /**

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -270,7 +270,16 @@ object ZQuerySpec extends ZIOBaseSpec {
             isAfterRan  <- afterRef.get
           } yield assert(isBeforeRan)(equalTo(1)) && assert(isAfterRan)(equalTo(2))
         }
-      ) @@ nonFlaky
+      ) @@ nonFlaky,
+      test("service methods works with multiple services") {
+        def getFoo: ZQuery[Int with String, Nothing, Unit] =
+          ZQuery.serviceWithQuery[Int](_ => ZQuery.service[String].as(()))
+
+        def getBar: ZQuery[Int with String, Nothing, Unit] =
+          ZQuery.serviceWithZIO[String](_ => ZIO.service[String].unit)
+
+        assertCompletes
+      }
     ) @@ silent
 
   val userIds: List[Int]          = (1 to 26).toList


### PR DESCRIPTION
`serviceWithZIO` and `serviceWithQuery` seem to suffer from some inference issues when used in particular patterns for instance:

```scala
def getFoo: ZQuery[Service with Auth, Nothing, Unit] =
  ZQuery.serviceWithQuery[Service](_.doAuthedThing)
```

If `doAuthedThing` added additional types to the service requirement, this didn't compile.