### PR TITLE
Implement QueryAspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ lazy val userQuery: ZQuery[Any, Nothing, List[String]] = for {
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-query" % "0.3.4"
+libraryDependencies += "dev.zio" %% "zio-query" % "0.3.6"
 ```
 
 ## Example

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -43,6 +43,12 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 trait DataSource[-R, -A] { self =>
 
   /**
+   * Syntax for adding aspects.
+   */
+  final def @@[R1 <: R](aspect: => DataSourceAspect[R1])(implicit trace: Trace): DataSource[R1, A] =
+    aspect(self)
+
+  /**
    * The data source's identifier.
    */
   val identifier: String

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -45,7 +45,7 @@ trait DataSource[-R, -A] { self =>
   /**
    * Syntax for adding aspects.
    */
-  final def @@[R1 <: R](aspect: => DataSourceAspect[R1]): DataSource[R1, A] =
+  final def @@[R1 <: R](aspect: DataSourceAspect[R1]): DataSource[R1, A] =
     aspect(self)
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -45,7 +45,7 @@ trait DataSource[-R, -A] { self =>
   /**
    * Syntax for adding aspects.
    */
-  final def @@[R1 <: R](aspect: => DataSourceAspect[R1])(implicit trace: Trace): DataSource[R1, A] =
+  final def @@[R1 <: R](aspect: => DataSourceAspect[R1]): DataSource[R1, A] =
     aspect(self)
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
@@ -80,7 +80,7 @@ object QueryAspect {
   )(after: A => ZIO[R, Nothing, Any]): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
     new QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] {
       def apply[R1 <: R, E, B](query: ZQuery[R1, E, B])(implicit trace: Trace): ZQuery[R1, E, B] =
-        ZQuery.acquireReleaseWith[R1, E, A, B](before)(after)(_ => query)
+        ZQuery.acquireReleaseWith(before)(after)(_ => query)
     }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.query
+
+import zio._
+
+trait QueryAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerA, -UpperA] { self =>
+
+  def apply[R >: LowerR <: UpperR, E >: LowerE <: UpperE, A >: LowerA <: UpperA](query: ZQuery[R, E, A])(implicit
+    trace: Trace
+  ): ZQuery[R, E, A]
+
+  def >>>[
+    LowerR1 >: LowerR,
+    UpperR1 <: UpperR,
+    LowerE1 >: LowerE,
+    UpperE1 <: UpperE,
+    LowerA1 >: LowerA,
+    UpperA1 <: UpperA
+  ](
+    that: QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1]
+  ): QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1] =
+    self.andThen(that)
+
+  /**
+   * Returns a new aspect that represents the sequential composition of this
+   * aspect with the specified one.
+   */
+  def @@[
+    LowerR1 >: LowerR,
+    UpperR1 <: UpperR,
+    LowerE1 >: LowerE,
+    UpperE1 <: UpperE,
+    LowerA1 >: LowerA,
+    UpperA1 <: UpperA
+  ](
+    that: QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1]
+  ): QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1] =
+    self >>> that
+
+  def andThen[
+    LowerR1 >: LowerR,
+    UpperR1 <: UpperR,
+    LowerE1 >: LowerE,
+    UpperE1 <: UpperE,
+    LowerA1 >: LowerA,
+    UpperA1 <: UpperA
+  ](
+    that: QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1]
+  ): QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1] =
+    new QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1] {
+      def apply[R >: LowerR1 <: UpperR1, E >: LowerE1 <: UpperE1, A >: LowerA1 <: UpperA1](
+        query: ZQuery[R, E, A]
+      )(implicit trace: Trace): ZQuery[R, E, A] =
+        that(self(query))
+    }
+}
+
+object QueryAspect {
+
+  def aroundDataSource[R, A](
+    before: Described[ZIO[R, Nothing, A]]
+  )(after: Described[A => ZIO[R, Nothing, Any]]): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
+    fromDataSourceAspect(DataSourceAspect.around(before)(after))
+
+  def fromDataSourceAspect[R](dataSourceAspect: DataSourceAspect[R]): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
+    new QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] {
+      def apply[R1 <: R, E, A](query: ZQuery[R1, E, A])(implicit trace: Trace): ZQuery[R1, E, A] =
+        query.mapDataSources(dataSourceAspect)
+    }
+
+  def maxBatchSize(n: Int): QueryAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    fromDataSourceAspect(DataSourceAspect.maxBatchSize(n))
+}

--- a/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
@@ -73,7 +73,7 @@ object QueryAspect {
 
   /**
    * A query aspect that executes queries between two effects, `before` and
-   * `after`..
+   * `after`.
    */
   def around[R, A](
     before: ZIO[R, Nothing, A]

--- a/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
@@ -18,12 +18,23 @@ package zio.query
 
 import zio._
 
+/**
+ * A `QueryAspect` is an aspect that can be weaved into queries. You can think
+ * of an aspect as a polymorphic function, capable of transforming one data
+ * source into another, possibly enlarging the environment type.
+ */
 trait QueryAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerA, -UpperA] { self =>
 
+  /**
+   * Applies the aspect to a query.
+   */
   def apply[R >: LowerR <: UpperR, E >: LowerE <: UpperE, A >: LowerA <: UpperA](query: ZQuery[R, E, A])(implicit
     trace: Trace
   ): ZQuery[R, E, A]
 
+  /**
+   * A symbolic alias for `andThen`.
+   */
   def >>>[
     LowerR1 >: LowerR,
     UpperR1 <: UpperR,
@@ -40,18 +51,6 @@ trait QueryAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerA, -UpperA] { self =
    * Returns a new aspect that represents the sequential composition of this
    * aspect with the specified one.
    */
-  def @@[
-    LowerR1 >: LowerR,
-    UpperR1 <: UpperR,
-    LowerE1 >: LowerE,
-    UpperE1 <: UpperE,
-    LowerA1 >: LowerA,
-    UpperA1 <: UpperA
-  ](
-    that: QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1]
-  ): QueryAspect[LowerR1, UpperR1, LowerE1, UpperE1, LowerA1, UpperA1] =
-    self >>> that
-
   def andThen[
     LowerR1 >: LowerR,
     UpperR1 <: UpperR,
@@ -73,7 +72,8 @@ trait QueryAspect[+LowerR, -UpperR, +LowerE, -UpperE, +LowerA, -UpperA] { self =
 object QueryAspect {
 
   /**
-   * Executes the specified workflows before and after the query.
+   * A query aspect that executes queries between two effects, `before` and
+   * `after`..
    */
   def around[R, A](
     before: ZIO[R, Nothing, A]
@@ -83,11 +83,19 @@ object QueryAspect {
         ZQuery.acquireReleaseWith[R1, E, A, B](before)(_ => after)(_ => query)
     }
 
+  /**
+   * A query aspect that executes requests between two effects, `before` and
+   * `after`, where the result of `before` can be used by `after`.
+   */
   def aroundDataSource[R, A](
     before: Described[ZIO[R, Nothing, A]]
   )(after: Described[A => ZIO[R, Nothing, Any]]): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
     fromDataSourceAspect(DataSourceAspect.around(before)(after))
 
+  /**
+   * A query aspect that executes requests with the specified data source
+   * aspect.
+   */
   def fromDataSourceAspect[R](
     dataSourceAspect: DataSourceAspect[R]
   ): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
@@ -96,6 +104,10 @@ object QueryAspect {
         query.mapDataSources(dataSourceAspect)
     }
 
+  /**
+   * A query aspect that limits data sources to executing at most `n` requests
+   * in parallel.
+   */
   def maxBatchSize(n: Int): QueryAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     fromDataSourceAspect(DataSourceAspect.maxBatchSize(n))
 }

--- a/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
+++ b/zio-query/shared/src/main/scala/zio/query/QueryAspect.scala
@@ -73,14 +73,14 @@ object QueryAspect {
 
   /**
    * A query aspect that executes queries between two effects, `before` and
-   * `after`.
+   * `after`, where the result of `before` can be used by `after`.
    */
   def around[R, A](
     before: ZIO[R, Nothing, A]
-  )(after: ZIO[R, Nothing, Any]): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
+  )(after: A => ZIO[R, Nothing, Any]): QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] =
     new QueryAspect[Nothing, R, Nothing, Any, Nothing, Any] {
       def apply[R1 <: R, E, B](query: ZQuery[R1, E, B])(implicit trace: Trace): ZQuery[R1, E, B] =
-        ZQuery.acquireReleaseWith[R1, E, A, B](before)(_ => after)(_ => query)
+        ZQuery.acquireReleaseWith[R1, E, A, B](before)(after)(_ => query)
     }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -60,6 +60,9 @@ import scala.reflect.ClassTag
  */
 final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result[R, E, A]]) { self =>
 
+  /**
+   * Syntax for adding aspects.
+   */
   final def @@[LowerR <: UpperR, UpperR <: R, LowerE >: E, UpperE >: LowerE, LowerA >: A, UpperA >: LowerA](
     aspect: => QueryAspect[LowerR, UpperR, LowerE, UpperE, LowerA, UpperA]
   )(implicit trace: Trace): ZQuery[UpperR, LowerE, LowerA] =

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -60,11 +60,10 @@ import scala.reflect.ClassTag
  */
 final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result[R, E, A]]) { self =>
 
-  /**
-   * Syntax for adding aspects.
-   */
-  final def @@[R1 <: R](aspect: => DataSourceAspect[R1])(implicit trace: Trace): ZQuery[R1, E, A] =
-    mapDataSources(aspect)
+  final def @@[LowerR <: UpperR, UpperR <: R, LowerE >: E, UpperE >: LowerE, LowerA >: A, UpperA >: LowerA](
+    aspect: => QueryAspect[LowerR, UpperR, LowerE, UpperE, LowerA, UpperA]
+  )(implicit trace: Trace): ZQuery[UpperR, LowerE, LowerA] =
+    ZQuery.suspend(aspect(self))
 
   /**
    * A symbolic alias for `zipParRight`.

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -1,7 +1,7 @@
 package zio.query
 
 import zio._
-import zio.query.DataSourceAspect._
+import zio.query.QueryAspect._
 import zio.test.Assertion._
 import zio.test.TestAspect.{after, nonFlaky, silent}
 import zio.test._
@@ -263,7 +263,7 @@ object ZQuerySpec extends ZIOBaseSpec {
 
             afterRef    <- Ref.make(0)
             after        = (v: Int) => afterRef.set(v * 2)
-            aspect       = DataSourceAspect.around(Described(before, "before effect"))(Described(after, "after effect"))
+            aspect       = QueryAspect.aroundDataSource(Described(before, "before effect"))(Described(after, "after effect"))
             query        = getUserNameById(1) @@ aspect
             _           <- query.run
             isBeforeRan <- beforeRef.get

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -280,7 +280,7 @@ object ZQuerySpec extends ZIOBaseSpec {
           acquire = ref.update(_ + 1)
           release = ref.update(_ - 1)
           fiber <- ZQuery
-                     .acquireReleaseWith[Cache, Nothing, Unit, Unit](acquire)(_ => release)(_ => query(100))
+                     .acquireReleaseWith(acquire)(_ => release)(_ => query(100))
                      .run
                      .fork
           _     <- fiber.interrupt

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -274,13 +274,13 @@ object ZQuerySpec extends ZIOBaseSpec {
       test("acquireReleaseWith") {
         def query(n: Int): ZQuery[Cache, Nothing, Unit] =
           if (n == 0) ZQuery.unit
-          else ZQuery.fromZIO(Random.nextInt).flatMap(Cache.get(_).flatMap(_ => workflow(n - 1)))
+          else ZQuery.fromZIO(Random.nextInt).flatMap(Cache.get(_).flatMap(_ => query(n - 1)))
         for {
           ref    <- Ref.make(0)
           acquire = ref.update(_ + 1)
           release = ref.update(_ - 1)
           fiber <- ZQuery
-                     .acquireReleaseWith[Cache, Nothing, Unit, Unit](acquire)(_ => release)(_ => workflow(100))
+                     .acquireReleaseWith[Cache, Nothing, Unit, Unit](acquire)(_ => release)(_ => query(100))
                      .run
                      .fork
           _     <- fiber.interrupt


### PR DESCRIPTION
Resolves #416. A `QueryAspect` is like a `ZIOAspect` in that it modifies some aspect of how a query gets executed. Note that this would be a breaking change.