### PR TITLE
Optimizations for `collectAllBatched` and `collectAllPar`

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -216,7 +216,7 @@ private[query] object Continue {
         effect(collectQueries(res.queries).map(bf.fromSpecific(continues)))
       case res: PartitionResults.Mix[R, E, A] =>
         val query = collectQueries(res.queries.queries).flatMap { as =>
-          val array     = Array.ofDim[AnyRef](continues.size)
+          val array     = Array.ofDim[AnyRef](res.size)
           val addValues = populateArr(array) _
           addValues(as, res.queries.idx)
           ZQuery.fromZIO(ZIO.collectAll(res.ios.results)).map { as =>
@@ -275,7 +275,9 @@ private[query] object Continue {
     case class AllIos[E, A](ios: Chunk[IO[E, A]])                   extends PartitionedResults
     case class AllQueries[R, E, A](queries: Chunk[ZQuery[R, E, A]]) extends PartitionedResults
 
-    case class Mix[R, E, A](ios: Mix.Ios[E, A], queries: Mix.Queries[R, E, A]) extends PartitionedResults
+    case class Mix[R, E, A](ios: Mix.Ios[E, A], queries: Mix.Queries[R, E, A]) extends PartitionedResults {
+      def size: Int = ios.results.size + queries.queries.size
+    }
     object Mix {
       case class Ios[E, A](results: Chunk[IO[E, A]], idx: Chunk[Int])
       case class Queries[R, E, A](queries: Chunk[ZQuery[R, E, A]], idx: Chunk[Int])

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -139,11 +139,11 @@ private[query] object Result {
     bf: BuildFrom[Collection[Result[R, E, A]], A, Collection[A]],
     trace: Trace
   ): Result[R, E, Collection[A]] = {
-    def populateArr(arr: Array[AnyRef])(values: Chunk[A], idxs: Chunk[Int]): Unit = {
+    def populateArr(arr: Array[A])(values: Chunk[A], idxs: Chunk[Int]): Unit = {
       var i    = 0
       val size = idxs.size
       while (i < size) {
-        arr(idxs(i)) = values(i).asInstanceOf[AnyRef]
+        arr(idxs(i)) = values(i)
         i += 1
       }
     }
@@ -161,11 +161,11 @@ private[query] object Result {
       case res: PartitionedResults.Mix[R, E, A] =>
         val blockedRequests = collectBlocked(res.blocked.requests)
         val continue = collectContinue(res.blocked.continue).map { as =>
-          val array     = Array.ofDim[AnyRef](res.size)
+          val array     = Array.ofDim[AnyRef](res.size).asInstanceOf[Array[A]]
           val addValues = populateArr(array) _
           addValues(as, res.blocked.idx)
           addValues(res.done.results, res.done.idx)
-          bf.fromSpecific(results)(array.asInstanceOf[Array[A]])
+          bf.fromSpecific(results)(array)
         }
         Result.blocked(blockedRequests, continue)
       case failed: PartitionedResults.Failed[E] =>

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -236,7 +236,7 @@ private[query] object Result {
     case class AllDone[A](results: Chunk[A]) extends PartitionedResults
     case class AllBlocked[R, E, A](blocked: Chunk[BlockedRequests[R]], continue: Chunk[Continue[R, E, A]])
         extends PartitionedResults
-    case class Failed[E](causes: Chunk[Cause[E]])                             extends PartitionedResults
+    case class Failed[E](causes: Chunk[Cause[E]]) extends PartitionedResults
     case class Mix[R, E, A](blocked: Mix.Blocked[R, E, A], done: Mix.Done[A]) extends PartitionedResults {
       def size: Int = blocked.requests.size + done.results.size
     }

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -161,7 +161,7 @@ private[query] object Result {
       case res: PartitionedResults.Mix[R, E, A] =>
         val blockedRequests = collectBlocked(res.blocked.requests)
         val continue = collectContinue(res.blocked.continue).map { as =>
-          val array     = Array.ofDim[AnyRef](results.size)
+          val array     = Array.ofDim[AnyRef](res.size)
           val addValues = populateArr(array) _
           addValues(as, res.blocked.idx)
           addValues(res.done.results, res.done.idx)
@@ -237,7 +237,9 @@ private[query] object Result {
     case class AllBlocked[R, E, A](blocked: Chunk[BlockedRequests[R]], continue: Chunk[Continue[R, E, A]])
         extends PartitionedResults
     case class Failed[E](causes: Chunk[Cause[E]])                             extends PartitionedResults
-    case class Mix[R, E, A](blocked: Mix.Blocked[R, E, A], done: Mix.Done[A]) extends PartitionedResults
+    case class Mix[R, E, A](blocked: Mix.Blocked[R, E, A], done: Mix.Done[A]) extends PartitionedResults {
+      def size: Int = blocked.requests.size + done.results.size
+    }
 
     object Mix {
       case class Blocked[R, E, A](


### PR DESCRIPTION
Hi 👋 I was doing a series of optimizations for Caliban's GraphQL query executor (which relies heavily on `ZQuery.collectAllX`) and I noticed that there was a fair bit of time spent on calls to `ZQuery.collectAllBatched` / `ZQuery.collectAllPar`, especially for larger collections. I had a look at the code and thought to give it a go with rewriting the `Result.collectAllX` and `Continue.collectX` to use mutable datastructures and "naked" iterations in order to avoid boxing of primitives and allocations as much as possible.

I run the `collectAllBatched` benchmarks with, run with the `-prof gc` to profile GC allocations as well and in a nutshell:

Smaller collections (100 items):
- Increases throughput by ~40%
- Reduces GC allocations by ~35%

Larger collections (1,000 items):
- Increases throughput by ~100%
- Reduces GC allocations by ~50%

<details>
  <summary><b>Benchmark results (click to expand)</b></summary>
series 2/x:

```
[info] Benchmark                                                       (count)   Mode  Cnt       Score      Error   Units
[info] CollectAllBenchmark.zQueryCollectAllBatched                         100  thrpt   20  192050.951 ± 2643.135   ops/s
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate           100  thrpt   20    6501.672 ±   87.545  MB/sec
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate.norm      100  thrpt   20   35500.014 ±   10.690    B/op
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.count                100  thrpt   20     735.000             counts
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.time                 100  thrpt   20     417.000                 ms
[info] CollectAllBenchmark.zQueryCollectAllBatched                        1000  thrpt   20   18757.456 ±   39.011   ops/s
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate          1000  thrpt   20    6022.526 ±   11.236  MB/sec
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate.norm     1000  thrpt   20  336684.148 ±   81.987    B/op
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.count               1000  thrpt   20     681.000             counts
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.time                1000  thrpt   20     402.000                 ms
```

PR:

```
[info] Benchmark                                                       (count)   Mode  Cnt       Score      Error   Units
[info] CollectAllBenchmark.zQueryCollectAllBatched                         100  thrpt   20  269064.461 ± 2661.240   ops/s
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate           100  thrpt   20    5786.653 ±   60.588  MB/sec
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate.norm      100  thrpt   20   22552.009 ±   14.255    B/op
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.count                100  thrpt   20     654.000             counts
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.time                 100  thrpt   20     378.000                 ms
[info] CollectAllBenchmark.zQueryCollectAllBatched                        1000  thrpt   20   36614.670 ± 1175.908   ops/s
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate          1000  thrpt   20    6085.911 ±  195.697  MB/sec
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.alloc.rate.norm     1000  thrpt   20  174296.063 ±    7.125    B/op
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.count               1000  thrpt   20     688.000             counts
[info] CollectAllBenchmark.zQueryCollectAllBatched:gc.time                1000  thrpt   20     388.000                 ms
```
</details>

Please let me know what you think of these changes. I understand that it relies very heavily on mutable code and "naked" iterations, which might not be ideal, but I think it might be worth it to consider given the improvements in performance.

PS: I extracted the logic into generic `collectAllImpl` methods to keep things DRY, but I'm happy to add the code back to each method if you prefer that.