### PR TITLE
Allow creating `CompletedRequestMap`s from iterables

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -79,10 +79,13 @@ object CompletedRequestMap {
   val empty: CompletedRequestMap =
     new CompletedRequestMap(Map.empty)
 
+  /**
+   * Constructs a completed requests map from an existing Iterable of tuples
+   */
   def from[E, A, B](it: Iterable[(A, Exit[E, B])])(implicit ev: A <:< Request[E, B]): CompletedRequestMap =
     new CompletedRequestMap(Map.from(it))
 
-  def fromOptional[E, A, B](
+  private[query] def fromOptional[E, A, B](
     it: Iterable[(A, Exit[E, Option[B]])]
   )(implicit ev: A <:< Request[E, B]): CompletedRequestMap = {
     val builder = Map.newBuilder[A, Exit[E, B]]
@@ -96,6 +99,12 @@ object CompletedRequestMap {
       }
     }
     from(builder.result())
+  }
+
+  // Only used by Scala 2.12 where the `Map.from` method doesn't exist
+  private implicit class EnrichedMapOps[E, A, B](val map: Map.type) extends AnyVal {
+    def from[K, V](it: Iterable[(K, V)]): Map[K, V] =
+      (Map.newBuilder[K, V] ++= it).result
   }
 
 }

--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -102,7 +102,7 @@ object CompletedRequestMap {
   }
 
   // Only used by Scala 2.12 where the `Map.from` method doesn't exist
-  private implicit class EnrichedMapOps[E, A, B](val map: Map.type) extends AnyVal {
+  private implicit class EnrichedMapOps[E, A, B](private val map: Map.type) extends AnyVal {
     def from[K, V](it: Iterable[(K, V)]): Map[K, V] =
       (Map.newBuilder[K, V] ++= it).result
   }


### PR DESCRIPTION
In cases where users create custom datasources by extending `DataSource`, they need to add each individual result to the `CompletedRequestMap`. With this PR, we allow creating `CompletedRequestMap` via iterables.

Besides the UX improvement, this is also ~30% faster and generates ~50% less GC allocations