### PR TITLE
Unify `ZQuery.foreach` implementations and cleanups

### DIFF
--- a/benchmarks/src/main/scala/zio/query/FromRequestBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/query/FromRequestBenchmark.scala
@@ -33,6 +33,13 @@ class FromRequestBenchmark {
   }
 
   @Benchmark
+  def fromRequestUncached(): Long = {
+    val reqs  = Chunk.fromIterable((0 until count).map(i => ZQuery.fromRequest(Req(i))(ds)))
+    val query = ZQuery.collectAllBatched(reqs).map(_.sum.toLong)
+    unsafeRun(query.uncached)
+  }
+
+  @Benchmark
   def fromRequestZipRight(): Long = {
     val reqs  = Chunk.fromIterable((0 until count).map(i => ZQuery.fromRequest(Req(i))(ds)))
     val query = ZQuery.collectAllBatched(reqs).map(_.sum.toLong)

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,9 @@ lazy val zioQuery = crossProject(JSPlatform, JVMPlatform)
   .settings(enableZIO())
   .settings(scalacOptions += "-Wconf:msg=[zio.stacktracer.TracingImplicits.disableAutoTrace]:silent")
   .settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
+    ),
     scalacOptions ++=
       (if (scalaBinaryVersion.value == "3")
          Seq()

--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -21,6 +21,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.immutable.HashMap
 import scala.collection.mutable
+import scala.collection.compat._
 
 /**
  * A `CompletedRequestMap` is a universally quantified mapping from requests of
@@ -76,11 +77,8 @@ final class CompletedRequestMap private (private val map: HashMap[Any, Exit[Any,
   def isEmpty: Boolean =
     map.isEmpty
 
-  private[query] def toMutableMap: mutable.HashMap[Request[?, ?], Exit[Any, Any]] = {
-    val map0 = new mutable.HashMap[Request[?, ?], Exit[Any, Any]]()
-    map0.sizeHint(map.size)
-    map0 ++= map.asInstanceOf[HashMap[Request[?, ?], Exit[Any, Any]]]
-  }
+  private[query] def toMutableMap: mutable.HashMap[Request[?, ?], Exit[Any, Any]] =
+    mutable.HashMap.from(map.asInstanceOf[HashMap[Request[?, ?], Exit[Any, Any]]])
 
   override def toString: String =
     s"CompletedRequestMap(${map.mkString(", ")})"
@@ -97,11 +95,8 @@ object CompletedRequestMap {
   /**
    * Constructs a completed requests map from the specified results.
    */
-  def fromIterable[E, A](iterable: Iterable[(Request[E, A], Exit[E, A])]): CompletedRequestMap = {
-    val builder = HashMap.newBuilder[Any, Exit[Any, Any]]
-    builder ++= iterable
-    new CompletedRequestMap(builder.result())
-  }
+  def fromIterable[E, A](iterable: Iterable[(Request[E, A], Exit[E, A])]): CompletedRequestMap =
+    new CompletedRequestMap(HashMap.from(iterable))
 
   /**
    * Constructs a completed requests map from the specified optional results.

--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -19,9 +19,9 @@ package zio.query
 import zio.Exit
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
+import scala.collection.compat._
 import scala.collection.immutable.HashMap
 import scala.collection.mutable
-import scala.collection.compat._
 
 /**
  * A `CompletedRequestMap` is a universally quantified mapping from requests of

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -20,10 +20,9 @@ import zio._
 import zio.query.internal._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.collection.mutable.Builder
-import scala.reflect.ClassTag
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.compat.{BuildFrom => _, _}
-import scala.collection.mutable
+import scala.reflect.ClassTag
 
 /**
  * A `ZQuery[R, E, A]` is a purely functional description of an effectual query
@@ -1169,14 +1168,14 @@ object ZQuery {
     mode: Int // 0 = sequential, 1 = parallel, 2 = batched
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): Result[R, E, Collection[B]] = {
 
-    def addToArray(array: Array[AnyRef])(idxs: Chunk[RuntimeFlags], values: Chunk[B]): Unit =
+    def addToArray(array: Array[B])(idxs: Chunk[RuntimeFlags], values: Chunk[B]): Unit =
       if (idxs.nonEmpty) {
         var i       = 0
         val iter    = values.chunkIterator
         val idxIter = idxs.chunkIterator
         while (idxIter.hasNextAt(i)) {
           val idx   = idxIter.nextAt(i)
-          val value = iter.nextAt(i).asInstanceOf[AnyRef]
+          val value = iter.nextAt(i)
           array(idx) = value
           i += 1
         }
@@ -1223,7 +1222,7 @@ object ZQuery {
     val gets          = getBuilder.result()
     val getIndices    = getIndicesBuilder.result()
     val fails         = failBuilder.result()
-    val size          = index // Store in a val to avoid boxing of var when used in the Functions below
+    val size          = index // Store in a val to avoid boxing of var when used in the functions below
 
     if (gets.isEmpty && effects.isEmpty && fails.isEmpty)
       Result.done(bf.fromSpecific(as)(dones))
@@ -1231,10 +1230,10 @@ object ZQuery {
       val continue =
         if (effects.isEmpty) {
           val io = ZIO.collectAll(gets).map { gets =>
-            val array = Array.ofDim[AnyRef](size)
+            val array = Array.ofDim[B](size)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]])
             addToArray(array)(getIndices, gets)
             addToArray(array)(doneIndices, dones)
-            bf.fromSpecific(as)(array.asInstanceOf[Array[B]])
+            bf.fromSpecific(as)(array)
           }
           Continue.get(io)
         } else {
@@ -1245,11 +1244,11 @@ object ZQuery {
           }
           val query = collect.mapZIO { effects =>
             ZIO.collectAll(gets).map { gets =>
-              val array = Array.ofDim[AnyRef](size)
+              val array = Array.ofDim[B](size)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]])
               addToArray(array)(effectIndices, effects)
               addToArray(array)(getIndices, gets)
               addToArray(array)(doneIndices, dones)
-              bf.fromSpecific(as)(array.asInstanceOf[Array[B]])
+              bf.fromSpecific(as)(array)
             }
           }
           Continue.effect(query)
@@ -1337,26 +1336,28 @@ object ZQuery {
                 ZIO.succeed(
                   Result.blocked(
                     BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
-                    Continue[R, E, A, B](promise)
+                    Continue(promise)
                   )
                 )
               case Right(promise) =>
                 promise.poll.flatMap {
-                  case None     => ZIO.succeed(Result.blocked(BlockedRequests.empty, Continue[R, E, A, B](promise)))
+                  case None     => ZIO.succeed(Result.blocked(BlockedRequests.empty, Continue(promise)))
                   case Some(io) => io.exit.map(Result.fromExit)
                 }
             }
             ZQuery.currentCache.getWith {
-              case cache: Cache.Default => foldPromise(cache.lookupUnsafe(request, fiberId)(Unsafe.unsafe, implicitly))
+              case cache: Cache.Default => foldPromise(cache.lookupUnsafe(request, fiberId)(Unsafe.unsafe))
               case cache                => cache.lookup(request).flatMap(foldPromise)
             }
-          } else
-            Promise.makeAs[E, B](fiberId).map { promise =>
+          } else {
+            ZIO.succeed {
+              val promise = Promise.unsafe.make[E, B](fiberId)(Unsafe.unsafe)
               Result.blocked(
                 BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
-                Continue[R, E, A, B](promise)
+                Continue(promise)
               )
             }
+          }
         }
       }
     }
@@ -1528,23 +1529,17 @@ object ZQuery {
           query.step.raceWith[R, Nothing, Nothing, B1, Result[R, E, B1]](fiber.join)(
             (leftExit, rightFiber) =>
               leftExit.foldExitZIO(
-                cause => rightFiber.interrupt *> ZIO.succeed(Result.fail(cause)),
-                result =>
-                  result match {
-                    case Result.Blocked(blockedRequests, continue) =>
-                      continue match {
-                        case Continue.Effect(query) =>
-                          ZIO.succeed(Result.blocked(blockedRequests, Continue.effect(race(query, fiber))))
-                        case Continue.Get(io) =>
-                          ZIO.succeed(
-                            Result.blocked(blockedRequests, Continue.effect(race(ZQuery.fromZIONow(io), fiber)))
-                          )
-                      }
-                    case Result.Done(value) => rightFiber.interrupt *> ZIO.succeed(Result.done(value))
-                    case Result.Fail(cause) => rightFiber.interrupt *> ZIO.succeed(Result.fail(cause))
-                  }
+                cause => rightFiber.interrupt.as(Result.fail(cause)),
+                {
+                  case Result.Blocked(blockedRequests, Continue.Effect(query)) =>
+                    ZIO.succeed(Result.blocked(blockedRequests, Continue.effect(race(query, fiber))))
+                  case Result.Blocked(blockedRequests, Continue.Get(io)) =>
+                    ZIO.succeed(Result.blocked(blockedRequests, Continue.effect(race(ZQuery.fromZIONow(io), fiber))))
+                  case Result.Done(value) => rightFiber.interrupt.as(Result.done(value))
+                  case Result.Fail(cause) => rightFiber.interrupt.as(Result.fail(cause))
+                }
               ),
-            (rightExit, leftFiber) => leftFiber.interrupt *> ZIO.succeed(Result.fromExit(rightExit))
+            (rightExit, leftFiber) => leftFiber.interrupt.as(Result.fromExit(rightExit))
           )
         }
 
@@ -1628,39 +1623,38 @@ object ZQuery {
       ZQuery.unwrap {
         ZQuery.currentScope.getWith { scope =>
           ZIO.environmentWithZIO[R] { environment =>
-            Ref.make(true).flatMap { ref =>
-              ZIO.uninterruptible {
-                ZIO.suspendSucceed(acquire()).tap { a =>
-                  scope.addFinalizerExit {
-                    case Exit.Failure(cause) =>
-                      release(a, Exit.failCause(cause.stripFailures))
-                        .provideEnvironment(environment)
-                        .whenZIO(ref.getAndSet(false))
-                    case Exit.Success(_) =>
-                      ZIO.unit
-                  }
+            val ref = new AtomicBoolean(true)
+            ZIO.uninterruptible {
+              ZIO.suspendSucceed(acquire()).tap { a =>
+                scope.addFinalizerExit {
+                  case Exit.Failure(cause) =>
+                    release(a, Exit.failCause(cause.stripFailures))
+                      .provideEnvironment(environment)
+                      .when(ref.getAndSet(false))
+                  case Exit.Success(_) =>
+                    ZIO.unit
                 }
-              }.map { a =>
-                ZQuery
-                  .suspend(use(a))
-                  .foldCauseQuery(
-                    cause =>
-                      ZQuery.fromZIONow {
-                        ZIO
-                          .suspendSucceed(release(a, Exit.failCause(cause)))
-                          .whenZIO(ref.getAndSet(false))
-                          .mapErrorCause(cause ++ _) *>
-                          ZIO.refailCause(cause)
-                      },
-                    b =>
-                      ZQuery.fromZIONow {
-                        ZIO
-                          .suspendSucceed(release(a, Exit.succeed(b)))
-                          .whenZIO(ref.getAndSet(false))
-                          .as(b)
-                      }
-                  )
               }
+            }.map { a =>
+              ZQuery
+                .suspend(use(a))
+                .foldCauseQuery(
+                  cause =>
+                    ZQuery.fromZIONow {
+                      ZIO
+                        .suspendSucceed(release(a, Exit.failCause(cause)))
+                        .when(ref.getAndSet(false))
+                        .mapErrorCause(cause ++ _) *>
+                        ZIO.refailCause(cause)
+                    },
+                  b =>
+                    ZQuery.fromZIONow {
+                      ZIO
+                        .suspendSucceed(release(a, Exit.succeed(b)))
+                        .when(ref.getAndSet(false))
+                        .as(b)
+                    }
+                )
             }
           }
         }

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -22,6 +22,8 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.Builder
 import scala.reflect.ClassTag
+import scala.collection.compat.{BuildFrom => _, _}
+import scala.collection.mutable
 
 /**
  * A `ZQuery[R, E, A]` is a purely functional description of an effectual query
@@ -1010,16 +1012,15 @@ object ZQuery {
   )(
     f: A => ZQuery[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    if (as.isEmpty) ZQuery.succeed(bf.newBuilder(as).result())
-    else {
-      val iterator                                         = as.iterator
-      var builder: ZQuery[R, E, Builder[B, Collection[B]]] = null
-      while (iterator.hasNext) {
-        val a = iterator.next()
-        if (builder eq null) builder = f(a).map(bf.newBuilder(as) += _)
-        else builder = builder.zipWith(f(a))(_ += _)
-      }
-      builder.map(_.result())
+    as.sizeCompare(1) match {
+      case -1 => ZQuery.succeed(bf.newBuilder(as).result())
+      case 0  => f(as.head).map(bf.newBuilder(as) += _).map(_.result())
+      case _ =>
+        ZQuery {
+          ZIO
+            .foreach[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
+            .map(collectResults(as, _, mode = 0))
+        }
     }
 
   /**
@@ -1089,112 +1090,16 @@ object ZQuery {
   )(
     f: A => ZQuery[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    if (as.isEmpty) ZQuery.succeed(bf.newBuilder(as).result())
-    else
-      ZQuery(
-        ZIO.suspendSucceed {
-          var blockedRequests: BlockedRequests[R]          = BlockedRequests.empty
-          val doneBuilder: Builder[B, Collection[B]]       = bf.newBuilder(as)
-          val doneIndicesBuilder: ChunkBuilder[Int]        = new ChunkBuilder.Int
-          val effectBuilder: ChunkBuilder[ZQuery[R, E, B]] = ChunkBuilder.make[ZQuery[R, E, B]]()
-          val effectIndicesBuilder: ChunkBuilder[Int]      = new ChunkBuilder.Int
-          val failBuilder: ChunkBuilder[Cause[E]]          = ChunkBuilder.make[Cause[E]]()
-          val getBuilder: ChunkBuilder[IO[E, B]]           = ChunkBuilder.make[IO[E, B]]()
-          val getIndicesBuilder: ChunkBuilder[Int]         = new ChunkBuilder.Int
-          var index: Int                                   = 0
-          val iterator: Iterator[A]                        = as.iterator
-
-          ZIO.whileLoop {
-            iterator.hasNext
-          } {
-            f(iterator.next()).step
-          } {
-            case Result.Blocked(blockedRequest, Continue.Effect(query)) =>
-              blockedRequests = blockedRequests && blockedRequest
-              effectBuilder += query
-              effectIndicesBuilder += index
-              index += 1
-            case Result.Blocked(blockedRequest, Continue.Get(io)) =>
-              blockedRequests = blockedRequests && blockedRequest
-              getBuilder += io
-              getIndicesBuilder += index
-              index += 1
-            case Result.Done(b) =>
-              doneBuilder += b
-              doneIndicesBuilder += index
-              index += 1
-            case Result.Fail(e) =>
-              failBuilder += e
-              index += 1
-          }.as {
-            val dones   = doneBuilder.result()
-            val effects = effectBuilder.result()
-            val fails   = failBuilder.result()
-            val gets    = getBuilder.result()
-            if (gets.isEmpty && effects.isEmpty && fails.isEmpty) {
-              Result.done(bf.fromSpecific(as)(dones))
-            } else if (fails.isEmpty) {
-              val continue = if (effects.isEmpty) {
-                val getIndices  = getIndicesBuilder.result()
-                val doneIndices = doneIndicesBuilder.result()
-                val io = ZIO.collectAll(gets).map { gets =>
-                  val array              = Array.ofDim[AnyRef](index)
-                  val getsIterator       = gets.iterator
-                  val getIndicesIterator = getIndices.iterator
-                  while (getsIterator.hasNext) {
-                    val get   = getsIterator.next()
-                    val index = getIndicesIterator.next()
-                    array(index) = get.asInstanceOf[AnyRef]
-                  }
-                  val donesIterator       = dones.iterator
-                  val doneIndicesIterator = doneIndices.iterator
-                  while (donesIterator.hasNext) {
-                    val done  = donesIterator.next()
-                    val index = doneIndicesIterator.next()
-                    array(index) = done.asInstanceOf[AnyRef]
-                  }
-                  bf.fromSpecific(as)(array.asInstanceOf[Array[B]])
-                }
-                Continue.get(io)
-              } else {
-                val effectIndices = effectIndicesBuilder.result()
-                val getIndices    = getIndicesBuilder.result()
-                val doneIndices   = doneIndicesBuilder.result()
-                val query = ZQuery.collectAllBatched(effects).flatMap { effects =>
-                  ZQuery.fromZIONow(ZIO.collectAll(gets).map { gets =>
-                    val array                 = Array.ofDim[AnyRef](index)
-                    val effectsIterator       = effects.iterator
-                    val effectIndicesIterator = effectIndices.iterator
-                    while (effectsIterator.hasNext) {
-                      val effect = effectsIterator.next()
-                      val index  = effectIndicesIterator.next()
-                      array(index) = effect.asInstanceOf[AnyRef]
-                    }
-                    val getsIterator       = gets.iterator
-                    val getIndicesIterator = getIndices.iterator
-                    while (getsIterator.hasNext) {
-                      val get   = getsIterator.next()
-                      val index = getIndicesIterator.next()
-                      array(index) = get.asInstanceOf[AnyRef]
-                    }
-                    val donesIterator       = dones.iterator
-                    val doneIndicesIterator = doneIndices.iterator
-                    while (donesIterator.hasNext) {
-                      val done  = donesIterator.next()
-                      val index = doneIndicesIterator.next()
-                      array(index) = done.asInstanceOf[AnyRef]
-                    }
-                    bf.fromSpecific(as)(array.asInstanceOf[Array[B]])
-                  })
-                }
-                Continue.effect(query)
-              }
-              Result.blocked(blockedRequests, continue)
-            } else
-              Result.fail(fails.foldLeft[Cause[E]](Cause.empty)(_ && _))
-          }
+    as.sizeCompare(1) match {
+      case -1 => ZQuery.succeed(bf.newBuilder(as).result())
+      case 0  => f(as.head).map(bf.newBuilder(as) += _).map(_.result())
+      case _ =>
+        ZQuery {
+          ZIO
+            .foreach[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
+            .map(collectResults(as, _, mode = 2))
         }
-      )
+    }
 
   final def foreachBatched[R, E, A, B](as: Set[A])(fn: A => ZQuery[R, E, B])(implicit
     trace: Trace
@@ -1247,25 +1152,112 @@ object ZQuery {
   )(
     f: A => ZQuery[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    ZQuery.suspend {
-      if (as.isEmpty)
-        ZQuery.succeed(bf.newBuilder(as).result())
-      else if (isSingleElementIterable(as))
-        f(as.head).map(bf.newBuilder(as) += _).map(_.result())
-      else
-        ZQuery(
+    as.sizeCompare(1) match {
+      case -1 => ZQuery.succeed(bf.newBuilder(as).result())
+      case 0  => f(as.head).map(bf.newBuilder(as) += _).map(_.result())
+      case _ =>
+        ZQuery {
           ZIO
             .foreachPar[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
-            .map(Result.collectAllPar(_).map(bf.fromSpecific(as)))
-        )
+            .map(collectResults(as, _, mode = 1))
+        }
     }
 
-  private def isSingleElementIterable(iterable: Iterable[?]): Boolean =
-    iterable match {
-      case _ :: Nil   => true
-      case _: List[?] => false
-      case _          => iterable.size == 1
+  private def collectResults[R, E, A, B, Collection[+Element] <: Iterable[Element]](
+    as: Collection[A],
+    results: Iterable[Result[R, E, B]],
+    mode: Int // 0 = sequential, 1 = parallel, 2 = batched
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): Result[R, E, Collection[B]] = {
+
+    def addToArray(array: Array[AnyRef])(idxs: Chunk[RuntimeFlags], values: Chunk[B]): Unit =
+      if (idxs.nonEmpty) {
+        var i       = 0
+        val iter    = values.chunkIterator
+        val idxIter = idxs.chunkIterator
+        while (idxIter.hasNextAt(i)) {
+          val idx   = idxIter.nextAt(i)
+          val value = iter.nextAt(i).asInstanceOf[AnyRef]
+          array(idx) = value
+          i += 1
+        }
+      }
+
+    var blockedRequests: BlockedRequests[R]          = BlockedRequests.empty
+    val doneBuilder: ChunkBuilder[B]                 = ChunkBuilder.make[B]()
+    val doneIndicesBuilder: ChunkBuilder[Int]        = new ChunkBuilder.Int
+    val effectBuilder: ChunkBuilder[ZQuery[R, E, B]] = ChunkBuilder.make[ZQuery[R, E, B]]()
+    val effectIndicesBuilder: ChunkBuilder[Int]      = new ChunkBuilder.Int
+    val failBuilder: ChunkBuilder[Cause[E]]          = ChunkBuilder.make[Cause[E]]()
+    val getBuilder: ChunkBuilder[IO[E, B]]           = ChunkBuilder.make[IO[E, B]]()
+    val getIndicesBuilder: ChunkBuilder[Int]         = new ChunkBuilder.Int
+    var index: Int                                   = 0
+    val iter                                         = results.iterator
+
+    while (iter.hasNext) {
+      iter.next() match {
+        case Result.Blocked(blockedRequest, continue) =>
+          blockedRequests = if (mode == 0) blockedRequests ++ blockedRequest else blockedRequests && blockedRequest
+          continue match {
+            case Continue.Effect(query) =>
+              effectBuilder.addOne(query)
+              effectIndicesBuilder.addOne(index)
+            case Continue.Get(io) =>
+              getBuilder.addOne(io)
+              getIndicesBuilder.addOne(index)
+          }
+          index += 1
+        case Result.Done(b) =>
+          doneBuilder.addOne(b)
+          doneIndicesBuilder.addOne(index)
+          index += 1
+        case Result.Fail(e) =>
+          failBuilder.addOne(e)
+          index += 1
+      }
     }
+
+    val dones         = doneBuilder.result()
+    val doneIndices   = doneIndicesBuilder.result()
+    val effects       = effectBuilder.result()
+    val effectIndices = effectIndicesBuilder.result()
+    val gets          = getBuilder.result()
+    val getIndices    = getIndicesBuilder.result()
+    val fails         = failBuilder.result()
+    val size          = index // Store in a val to avoid boxing of var when used in the Functions below
+
+    if (gets.isEmpty && effects.isEmpty && fails.isEmpty)
+      Result.done(bf.fromSpecific(as)(dones))
+    else if (fails.isEmpty) {
+      val continue =
+        if (effects.isEmpty) {
+          val io = ZIO.collectAll(gets).map { gets =>
+            val array = Array.ofDim[AnyRef](size)
+            addToArray(array)(getIndices, gets)
+            addToArray(array)(doneIndices, dones)
+            bf.fromSpecific(as)(array.asInstanceOf[Array[B]])
+          }
+          Continue.get(io)
+        } else {
+          val collect = mode match {
+            case 0 => ZQuery.collectAll(effects)
+            case 1 => ZQuery.collectAllPar(effects)
+            case 2 => ZQuery.collectAllBatched(effects)
+          }
+          val query = collect.mapZIO { effects =>
+            ZIO.collectAll(gets).map { gets =>
+              val array = Array.ofDim[AnyRef](size)
+              addToArray(array)(effectIndices, effects)
+              addToArray(array)(getIndices, gets)
+              addToArray(array)(doneIndices, dones)
+              bf.fromSpecific(as)(array.asInstanceOf[Array[B]])
+            }
+          }
+          Continue.effect(query)
+        }
+      Result.blocked(blockedRequests, continue)
+    } else
+      Result.fail(fails.foldLeft[Cause[E]](Cause.empty)(_ && _))
+  }
 
   /**
    * Performs a query for each element in a Set, collecting the results into a
@@ -1595,8 +1587,8 @@ object ZQuery {
     val cs = ChunkBuilder.make[C]()
     as.foreach { a =>
       f(a) match {
-        case Left(b)  => bs += b
-        case Right(c) => cs += c
+        case Left(b)  => bs addOne b
+        case Right(c) => cs addOne c
       }
     }
     (bs.result(), cs.result())

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -163,11 +163,8 @@ private[query] object Continue {
    * Constructs a continuation from a request, a data source, and a `Promise`
    * that will contain the result of the request when it is executed.
    */
-  def apply[R, E, A, B](promise: Promise[E, B])(implicit
-    ev: A <:< Request[E, B],
-    trace: Trace
-  ): Continue[R, E, B] =
-    Continue.get(promise.await)
+  def apply[E, A](promise: Promise[E, A])(implicit trace: Trace): Continue[Any, E, A] =
+    Get(promise.await)
 
   /**
    * Constructs a continuation that may perform arbitrary effects.

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -170,42 +170,6 @@ private[query] object Continue {
     Continue.get(promise.await)
 
   /**
-   * Collects a collection of continuation into a continuation returning a
-   * collection of their results, in parallel.
-   */
-  def collectAllPar[R, E, A, Collection[+Element] <: Iterable[Element]](
-    continues: Collection[Continue[R, E, A]]
-  )(implicit
-    bf: BuildFrom[Collection[Continue[R, E, A]], A, Collection[A]],
-    trace: Trace
-  ): Continue[R, E, Collection[A]] =
-    continues.zipWithIndex
-      .foldLeft[(Chunk[(ZQuery[R, E, A], Int)], Chunk[(IO[E, A], Int)])]((Chunk.empty, Chunk.empty)) {
-        case ((queries, ios), (continue, index)) =>
-          continue match {
-            case Effect(query) => (queries :+ ((query, index)), ios)
-            case Get(io)       => (queries, ios :+ ((io, index)))
-          }
-      } match {
-      case (Chunk(), ios) =>
-        get(ZIO.collectAll(ios.map(_._1)).map(bf.fromSpecific(continues)))
-      case (queries, ios) =>
-        val query = ZQuery.collectAllPar(queries.map(_._1)).flatMap { as =>
-          val array = Array.ofDim[AnyRef](continues.size)
-          as.zip(queries.map(_._2)).foreach { case (a, i) =>
-            array(i) = a.asInstanceOf[AnyRef]
-          }
-          ZQuery.fromZIONow(ZIO.collectAll(ios.map(_._1))).map { as =>
-            as.zip(ios.map(_._2)).foreach { case (a, i) =>
-              array(i) = a.asInstanceOf[AnyRef]
-            }
-            bf.fromSpecific(continues)(array.asInstanceOf[Array[A]])
-          }
-        }
-        effect(query)
-    }
-
-  /**
    * Constructs a continuation that may perform arbitrary effects.
    */
   def effect[R, E, A](query: ZQuery[R, E, A]): Continue[R, E, A] =

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -112,43 +112,6 @@ private[query] object Result {
     Blocked(blockedRequests, continue)
 
   /**
-   * Collects a collection of results into a single result. Blocked requests and
-   * their continuations will be executed in parallel.
-   */
-  def collectAllPar[R, E, A, Collection[+Element] <: Iterable[Element]](results: Collection[Result[R, E, A]])(implicit
-    bf: BuildFrom[Collection[Result[R, E, A]], A, Collection[A]],
-    trace: Trace
-  ): Result[R, E, Collection[A]] =
-    results.zipWithIndex
-      .foldLeft[(Chunk[((BlockedRequests[R], Continue[R, E, A]), Int)], Chunk[(A, Int)], Chunk[(Cause[E], Int)])](
-        (Chunk.empty, Chunk.empty, Chunk.empty)
-      ) { case ((blocked, done, fails), (result, index)) =>
-        result match {
-          case Blocked(br, c) => (blocked :+ (((br, c), index)), done, fails)
-          case Done(a)        => (blocked, done :+ ((a, index)), fails)
-          case Fail(e)        => (blocked, done, fails :+ ((e, index)))
-        }
-      } match {
-      case (Chunk(), done, Chunk()) =>
-        Result.done(bf.fromSpecific(results)(done.map(_._1)))
-      case (blocked, done, Chunk()) =>
-        val blockedRequests = blocked.map(_._1._1).foldLeft[BlockedRequests[R]](BlockedRequests.empty)(_ && _)
-        val continue = Continue.collectAllPar(blocked.map(_._1._2)).map { as =>
-          val array = Array.ofDim[AnyRef](results.size)
-          as.zip(blocked.map(_._2)).foreach { case (a, i) =>
-            array(i) = a.asInstanceOf[AnyRef]
-          }
-          done.foreach { case (a, i) =>
-            array(i) = a.asInstanceOf[AnyRef]
-          }
-          bf.fromSpecific(results)(array.asInstanceOf[Array[A]])
-        }
-        Result.blocked(blockedRequests, continue)
-      case (_, _, fail) =>
-        Result.fail(fail.map(_._1).foldLeft[Cause[E]](Cause.empty)(_ && _))
-    }
-
-  /**
    * Constructs a result that is done with the specified value.
    */
   def done[A](value: A): Result[Any, Nothing, A] =


### PR DESCRIPTION
The main change in this PR is that we unify the implementation for `foreach`, `foreachPar` and `foreachBatched`. This way, the `foreach` and `foreachPar` methods can take advantage of the optimizations that were done in https://github.com/zio/zio-query/pull/457.

The other somewhat big change is adding a dependency on `scala-collection-compat`. I was a bit divided about this at first, but I think it's likely for the best as I kept finding myself having to write workarounds for missing constructors / methods in Scala 2.12.
