### PR TITLE
Use `FiberId.None` when creating Promises

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/Cache.scala
+++ b/zio-query/shared/src/main/scala/zio/query/Cache.scala
@@ -86,12 +86,12 @@ object Cache {
       ev: A <:< Request[E, B],
       trace: Trace
     ): UIO[Either[Promise[E, B], Promise[E, B]]] =
-      ZIO.fiberId.map(lookupUnsafe(request, _)(Unsafe.unsafe))
+      ZIO.succeed(lookupUnsafe(request)(Unsafe.unsafe))
 
-    def lookupUnsafe[E, A, B](request: Request[_, _], fiberId: FiberId)(implicit
+    def lookupUnsafe[E, A, B](request: Request[_, _])(implicit
       unsafe: Unsafe
     ): Either[Promise[E, B], Promise[E, B]] = {
-      val newPromise = Promise.unsafe.make[E, B](fiberId)
+      val newPromise = Promise.unsafe.make[E, B](FiberId.None)
       val existing   = map.putIfAbsent(request, newPromise).asInstanceOf[Promise[E, B]]
       if (existing eq null) Left(newPromise) else Right(existing)
     }

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -298,15 +298,13 @@ private[query] object BlockedRequests {
   )(implicit trace: Trace): UIO[Unit] =
     cache match {
       case cache: Cache.Default =>
-        ZIO.fiberIdWith { fiberId =>
-          ZIO.succeedUnsafe { implicit unsafe =>
-            map.foreach { case (request: Request[Any, Any], exit) =>
-              cache
-                .lookupUnsafe(request, fiberId)
-                .merge
-                .unsafe
-                .done(exit)
-            }
+        ZIO.succeedUnsafe { implicit unsafe =>
+          map.foreach { case (request: Request[Any, Any], exit) =>
+            cache
+              .lookupUnsafe(request)
+              .merge
+              .unsafe
+              .done(exit)
           }
         }
       case cache =>


### PR DESCRIPTION
TIL that passing the `FiberId` passed to `Promise.unsafe.make` is not really needed. In fact, the only thing it's used for is that it's passed to the underlying `ZIO.asyncInterrupt`. From the scaladoc of `ZIO.asyncInterrupt`:

> Specifying this fiber id in cases where it is known will improve diagnostics, but not affect the behavior of the returned effect.

In light of this info, we pass `FiberId.None` (something used in other places as well in the ZIO codebase) so that we avoid its creation and the additional flatMaps