### PR TITLE
Additional `CompletedRequestMap` constructors and deprecations

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -17,7 +17,7 @@
 package zio.query
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Cause, Chunk, Exit, Unsafe}
+import zio.{Cause, Chunk, Exit}
 
 import scala.collection.compat._
 import scala.collection.{immutable, mutable}

--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -109,6 +109,13 @@ sealed abstract class CompletedRequestMap { self =>
 
 object CompletedRequestMap {
 
+  def apply[E, A](entries: (Request[E, A], Exit[E, A])*): CompletedRequestMap =
+    entries match {
+      case Seq()            => empty
+      case Seq((req, resp)) => single(req, resp)
+      case _                => fromIterable(entries)
+    }
+
   val empty: CompletedRequestMap =
     new Immutable(immutable.HashMap.empty)
 
@@ -118,9 +125,8 @@ object CompletedRequestMap {
    * This method is left-associated, meaning that if a request is present in
    * multiple maps, it will be overriden by the last map in the list.
    */
-  def fromCompletedRequestMaps(maps: Iterable[CompletedRequestMap]): CompletedRequestMap = {
-    val size = maps.foldLeft(0)(_ + _.map.size)
-    val map  = Mutable.empty(size)
+  def combine(maps: Iterable[CompletedRequestMap]): CompletedRequestMap = {
+    val map = Mutable.empty(maps.foldLeft(0)(_ + _.map.size))
     maps.foreach(map.addAll)
     map
   }
@@ -198,7 +204,7 @@ object CompletedRequestMap {
   /**
    * Unsafe API for constructing completed request maps.
    *
-   * Constructing a [[CompletedRequestMap]] via these megthods can improve
+   * Constructing a [[CompletedRequestMap]] via these methods can improve
    * performance in some cases as they allow skipping the creation of
    * intermediate `Iterable[ Tuple2[_, _] ]`.
    *

--- a/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
+++ b/zio-query/shared/src/main/scala/zio/query/CompletedRequestMap.scala
@@ -17,7 +17,7 @@
 package zio.query
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Cause, Chunk, Exit}
+import zio.{Cause, Chunk, Exit, Unsafe}
 
 import scala.collection.compat._
 import scala.collection.{immutable, mutable}
@@ -36,6 +36,15 @@ sealed abstract class CompletedRequestMap { self =>
 
   protected val map: collection.Map[Any, Exit[Any, Any]]
 
+  /**
+   * Appends the specified result to the completed requests map.
+   *
+   * @deprecated
+   *   Usage of this method is deprecated as it leads to performance
+   *   degradation. Prefer using one of the constructors in the companion object
+   *   instead
+   */
+  @deprecated("Use one of the constructors in the companion object instead. See scaladoc for more info", "0.7.0")
   final def ++(that: CompletedRequestMap): CompletedRequestMap =
     new CompletedRequestMap.Immutable(immutable.HashMap.from(map) ++ that.map)
 
@@ -46,14 +55,32 @@ sealed abstract class CompletedRequestMap { self =>
     map.contains(request)
 
   /**
-   * Appends the specified result to the completed requests map.
+   * Whether the completed requests map is empty.
    */
+  final def isEmpty: Boolean =
+    map.isEmpty
+
+  /**
+   * Appends the specified result to the completed requests map.
+   *
+   * @deprecated
+   *   Usage of this method is deprecated as it leads to performance
+   *   degradation. Prefer using one of the constructors in the companion object
+   *   instead
+   */
+  @deprecated("Use one of the constructors in the companion object instead. See scaladoc for more info", "0.7.0")
   final def insert[E, A](request: Request[E, A], result: Exit[E, A]): CompletedRequestMap =
     new CompletedRequestMap.Immutable(immutable.HashMap.from(map).updated(request, result))
 
   /**
    * Appends the specified optional result to the completed request map.
+   *
+   * @deprecated
+   *   Usage of this method is deprecated as it leads to performance
+   *   degradation. Prefer using one of the constructors in the companion object
+   *   instead
    */
+  @deprecated("Use one of the constructors in the companion object instead. See scaladoc for more info", "0.7.0")
   final def insertOption[E, A](request: Request[E, A], result: Exit[E, Option[A]]): CompletedRequestMap =
     result match {
       case Exit.Failure(e)       => insert(request, Exit.failCause(e))
@@ -73,17 +100,11 @@ sealed abstract class CompletedRequestMap { self =>
   final def requests: Set[Request[_, _]] =
     map.keySet.asInstanceOf[Set[Request[_, _]]]
 
-  /**
-   * Whether the completed requests map is empty.
-   */
-  final def isEmpty: Boolean =
-    map.isEmpty
-
-  final private[query] def toMutableMap: mutable.HashMap[Request[?, ?], Exit[Any, Any]] =
-    mutable.HashMap.from(map.asInstanceOf[collection.Map[Request[?, ?], Exit[Any, Any]]])
-
   final override def toString: String =
     s"CompletedRequestMap(${map.mkString(", ")})"
+
+  final private[query] def underlying: collection.Map[Request[?, ?], Exit[Any, Any]] =
+    map.asInstanceOf[collection.Map[Request[?, ?], Exit[Any, Any]]]
 }
 
 object CompletedRequestMap {
@@ -92,10 +113,45 @@ object CompletedRequestMap {
     new Immutable(immutable.HashMap.empty)
 
   /**
+   * Combines all completed request maps into a single one.
+   *
+   * This method is left-associated, meaning that if a request is present in
+   * multiple maps, it will be overriden by the last map in the list.
+   */
+  def fromCompletedRequestMaps(maps: Iterable[CompletedRequestMap]): CompletedRequestMap = {
+    val size = maps.foldLeft(0)(_ + _.map.size)
+    val map  = Mutable.empty(size)
+    maps.foreach(map.addAll)
+    map
+  }
+
+  /**
+   * Constructs a completed requests map that "dies" all the specified requests
+   * with the specified throwable
+   */
+  def die[E, A](requests: Chunk[Request[E, A]], error: Throwable): CompletedRequestMap = {
+    val map  = Mutable.empty(requests.size)
+    val exit = Exit.die(error)
+    requests.foreach(map.update(_, exit))
+    map
+  }
+
+  /**
+   * Constructs a completed requests map that fails all the specified requests
+   * with the specified error
+   */
+  def fail[E, A](requests: Chunk[Request[E, A]], error: E): CompletedRequestMap = {
+    val map  = Mutable.empty(requests.size)
+    val exit = Exit.fail(error)
+    requests.foreach(map.update(_, exit))
+    map
+  }
+
+  /**
    * Constructs a completed requests map that fails all the specified requests
    * with the specified cause
    */
-  def fail[E, A](requests: Chunk[Request[E, A]], cause: Cause[E]): CompletedRequestMap = {
+  def failCause[E, A](requests: Chunk[Request[E, A]], cause: Cause[E]): CompletedRequestMap = {
     val map  = Mutable.empty(requests.size)
     val exit = Exit.failCause(cause)
     requests.foreach(map.update(_, exit))
@@ -133,13 +189,33 @@ object CompletedRequestMap {
     map
   }
 
-  private[query] object unsafe {
+  /**
+   * Constructs a completed requests map containing a single entry
+   */
+  def single[E, A](request: Request[E, A], exit: Exit[E, A]): CompletedRequestMap =
+    new Immutable(immutable.HashMap((request, exit)))
 
-    def fromSuccesses[E, A, B](requests: Chunk[Request[E, B]], responses: Chunk[B]): CompletedRequestMap =
-      fromWith(requests, responses)(identity, Exit.succeed)
+  /**
+   * Unsafe API for constructing completed request maps.
+   *
+   * Constructing a [[CompletedRequestMap]] via these megthods can improve
+   * performance in some cases as they allow skipping the creation of
+   * intermediate `Iterable[ Tuple2[_, _] ]`.
+   *
+   * NOTE: These methods are marked as unsafe because they do not check that the
+   * requests and responses are of the same size. It is the responsibility of
+   * the caller to ensure that the provided requests maps elements 1-to-1 to the
+   * responses.
+   */
+  val unsafe: UnsafeApi = new UnsafeApi {}
 
-    def fromExits[E, A1, B](requests: Chunk[Request[E, B]], responses: Chunk[Exit[E, B]]): CompletedRequestMap =
+  trait UnsafeApi {
+
+    def fromExits[E, A](requests: Chunk[Request[E, A]], responses: Chunk[Exit[E, A]]): CompletedRequestMap =
       fromWith(requests, responses)(identity, identity)
+
+    def fromSuccesses[E, A](requests: Chunk[Request[E, A]], responses: Chunk[A]): CompletedRequestMap =
+      fromWith(requests, responses)(identity, Exit.succeed)
 
     def fromWith[E, A1, A2, B](requests: Chunk[A1], responses: Chunk[A2])(
       f1: A1 => Request[E, B],
@@ -172,6 +248,7 @@ object CompletedRequestMap {
 
     def update[E, A](request: Request[E, A], exit: Exit[E, A]): Unit =
       map.update(request, exit)
+
   }
 
   private[query] object Mutable {

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -17,7 +17,7 @@
 package zio.query
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Chunk, Exit, Trace, Unsafe, ZEnvironment, ZIO}
+import zio.{Chunk, Exit, Trace, ZEnvironment, ZIO}
 
 /**
  * A `DataSource[R, A]` requires an environment `R` and is capable of executing

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -17,7 +17,7 @@
 package zio.query
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Chunk, Exit, Trace, ZEnvironment, ZIO}
+import zio.{Chunk, Exit, Trace, Unsafe, ZEnvironment, ZIO}
 
 /**
  * A `DataSource[R, A]` requires an environment `R` and is capable of executing
@@ -35,10 +35,10 @@ import zio.{Chunk, Exit, Trace, ZEnvironment, ZIO}
  * though that is not strictly necessarily as long as the data source can map
  * the request type to a `Request[A]`. Data sources can then pattern match on
  * the collection of requests to determine the information requested, execute
- * the query, and place the results into the `CompletedRequestsMap` using
- * [[CompletedRequestMap.empty]] and [[CompletedRequestMap.insert]]. Data
- * sources must provide results for all requests received. Failure to do so will
- * cause a query to die with a `QueryFailure` when run.
+ * the query, and place the results into the `CompletedRequestsMap` one of the
+ * constructors in [[CompletedRequestMap$]]. Data sources must provide results
+ * for all requests received. Failure to do so will cause a query to die with a
+ * `QueryFailure` when run.
  */
 trait DataSource[-R, -A] { self =>
 
@@ -301,7 +301,7 @@ object DataSource {
       def run(requests: Chunk[A])(implicit trace: Trace): ZIO[R, Nothing, CompletedRequestMap] =
         f(requests)
           .foldCause(
-            e => CompletedRequestMap.fail(ev.liftCo(requests), e),
+            e => CompletedRequestMap.failCause(ev.liftCo(requests), e),
             bs => CompletedRequestMap.unsafe.fromWith(bs, bs)(g(_), Exit.succeed)
           )
 
@@ -321,7 +321,7 @@ object DataSource {
       def run(requests: Chunk[A])(implicit trace: Trace): ZIO[R, Nothing, CompletedRequestMap] =
         f(requests)
           .foldCause(
-            e => CompletedRequestMap.fail(ev.liftCo(requests), e),
+            e => CompletedRequestMap.failCause(ev.liftCo(requests), e),
             CompletedRequestMap.unsafe.fromSuccesses(ev.liftCo(requests), _)
           )
     }

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -19,9 +19,10 @@ package zio.query.internal
 import zio.query._
 import zio.query.internal.BlockedRequests._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Chunk, Exit, Promise, Trace, UIO, Unsafe, ZEnvironment, ZIO}
+import zio.{Chunk, Exit, Trace, UIO, Unsafe, ZEnvironment, ZIO}
 
 import scala.annotation.tailrec
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -113,7 +113,7 @@ private[query] sealed trait BlockedRequests[-R] { self =>
             .runAll(requests)
             .catchAllCause(cause =>
               ZIO.succeed {
-                CompletedRequestMap.fail(
+                CompletedRequestMap.failCause(
                   requests.flatten.asInstanceOf[Chunk[Request[Any, Any]]],
                   cause
                 )
@@ -121,7 +121,7 @@ private[query] sealed trait BlockedRequests[-R] { self =>
             )
             .flatMap { completedRequests =>
               ZQuery.cachingEnabled.getWith {
-                val completedRequestsM = completedRequests.toMutableMap
+                val completedRequestsM = mutable.HashMap.from(completedRequests.underlying)
                 if (_) {
                   completePromises(dataSource, sequential) { req =>
                     // Pop the entry, and fallback to the immutable one if we already removed it


### PR DESCRIPTION
This PR aims to improve UX by adding a few more ways to construct a `CompletedRequestMap`

### Deprecation of  `++`, `insert` and `insertOption` methods

The rationale behind this the deprecation of these methods is that prior to version 0.6.1, the only way to populate a `CompletedRequestMap` was by folding over an empty one and immutably inserting all the requests / responses to it. One of the major recent optimizations was for `CompletedRequestMap` to wrap a mutable map, however, in order for mutability not to leak to the public API the `++`, `insert` and `insertOption` methods still use immutable maps. This means that existing user code will not benefit from these optimizations until they use the new constructors added since then.

TLDR; The deprecation of these methods is simply meant as a way to signal to users (who don't read release notes) to avoid usage of these methods as they'll lead to suboptimal performance