### PR TITLE
New query constructors and method aliases

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -152,6 +152,21 @@ trait DataSource[-R, -A] { self =>
     }
 
   /**
+   * Submits a request to this datasource and returns the result.
+   */
+  final def query[E, A1 <: A, B](request: A1)(implicit ev: A1 <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
+    ZQuery.fromRequest(request)(self)
+
+  /**
+   * Submits a Chunk of requests to this datasource and returns the results in
+   * the same order
+   */
+  final def queryAll[E, A1 <: A, B](
+    requests: Chunk[A1]
+  )(implicit ev: A1 <:< Request[E, B], trace: Trace): ZQuery[R, E, Chunk[B]] =
+    ZQuery.fromRequests(requests)(self)
+
+  /**
    * Returns a new data source that executes requests by sending them to this
    * data source and that data source, returning the results from the first data
    * source to complete and safely interrupting the loser.

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1779,71 +1779,70 @@ object ZQuery {
 
   private object CachedResult {
 
+    final case class Pure[R, E, B](result: Result[R, E, B]) extends CachedResult[R, E, B] {
+      def toZIO: UIO[Result[R, E, B]] = Exit.succeed(result)
+    }
+
+    final case class Effectful[R, E, B](toZIO: UIO[Result[R, E, B]]) extends CachedResult[R, E, B]
+
     def foreach[R, E, A, B, Collection[+x] <: Iterable[x]](
       as: Collection[A]
     )(
       f: A => CachedResult[R, E, B]
     )(implicit
       trace: Trace,
-      bf1: BuildFrom[Collection[?], Result[R, E, B], Collection[Result[R, E, B]]],
-      bf2: BuildFrom[Collection[?], UIO[Result[R, E, B]], Collection[UIO[Result[R, E, B]]]]
-    ): UIO[Collection[Result[R, E, B]]] = ZIO.suspendSucceed {
-      val size    = as.size
-      val puresB  = bf1.newBuilder(as)
-      val pureIdx = new ChunkBuilder.Int
-      pureIdx.sizeHint(size)
+      bf: BuildFrom[Collection[A], Result[R, E, B], Collection[Result[R, E, B]]]
+    ): UIO[Collection[Result[R, E, B]]] =
+      ZIO.suspendSucceed {
+        val puresB  = bf.newBuilder(as)
+        val pureIdx = new ChunkBuilder.Int
 
-      val effectfulB   = bf2.newBuilder(as)
-      val effectfulIdx = new ChunkBuilder.Int
+        val effectfulB   = Chunk.newBuilder[UIO[Result[R, E, B]]]
+        val effectfulIdx = new ChunkBuilder.Int
 
-      val iter = as.iterator
-      var i    = 0
-      while (iter.hasNext) {
-        val next = f(iter.next())
-        next match {
-          case Pure(result) =>
-            puresB.addOne(result)
-            pureIdx.addOne(i)
-          case Effectful(io) =>
-            effectfulB.addOne(io)
-            effectfulIdx.addOne(i)
-        }
-        i += 1
-      }
-
-      val pures     = puresB.result()
-      val effectful = effectfulB.result()
-
-      if (effectful.isEmpty) ZIO.succeed(pures)
-      else if (pures.isEmpty) ZIO.collectAll(effectful)
-      else {
-        val pIdxs = pureIdx.result()
-        val eIdxs = effectfulIdx.result()
-        ZIO.collectAll(effectful).map { effectful =>
-          val arr = Array.ofDim[Result[R, E, B]](pIdxs.size + eIdxs.size)
-
-          def addToArray(idxs: Chunk[Int], values: Iterable[Result[R, E, B]]): Unit = {
-            val iter    = values.iterator
-            val idxIter = idxs.iterator
-            while (idxIter.hasNext) {
-              val idx   = idxIter.next()
-              val value = iter.next()
-              arr(idx) = value
-            }
+        val iter = as.iterator
+        var i    = 0
+        while (iter.hasNext) {
+          val next = f(iter.next())
+          next match {
+            case Pure(result) =>
+              puresB += result
+              pureIdx.addOne(i)
+            case Effectful(io) =>
+              effectfulB += io
+              effectfulIdx.addOne(i)
           }
+          i += 1
+        }
 
-          addToArray(pIdxs, pures)
-          addToArray(eIdxs, effectful)
-          bf1.fromSpecific(as)(arr)
+        val pures     = puresB.result()
+        val effectful = effectfulB.result()
+
+        if (effectful.isEmpty) ZIO.succeed(pures)
+        else if (pures.isEmpty) ZIO.collectAll(effectful).map(bf.fromSpecific(as))
+        else {
+          val pIdxs = pureIdx.result()
+          val eIdxs = effectfulIdx.result()
+
+          ZIO.collectAll(effectful).map { effectful =>
+            val arr = Array.ofDim[Result[R, E, B]](pIdxs.size + eIdxs.size)
+
+            def addToArray(idxs: Chunk[Int], values: Iterable[Result[R, E, B]]): Unit = {
+              val iter    = values.iterator
+              val idxIter = idxs.iterator
+              while (idxIter.hasNext) {
+                val idx   = idxIter.next()
+                val value = iter.next()
+                arr(idx) = value
+              }
+            }
+
+            addToArray(pIdxs, pures)
+            addToArray(eIdxs, effectful)
+            bf.fromSpecific(as)(arr)
+          }
         }
       }
-    }
-
-    final case class Pure[R, E, B](result: Result[R, E, B]) extends CachedResult[R, E, B] {
-      def toZIO: UIO[Result[R, E, B]] = Exit.succeed(result)
-    }
-
-    final case class Effectful[R, E, B](toZIO: UIO[Result[R, E, B]]) extends CachedResult[R, E, B]
   }
 
 }

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -76,12 +76,6 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
     zipParRight(that)
 
   /**
-   * A symbolic alias for `zipRight`.
-   */
-  final def *>[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, B] =
-    zipRight(that)
-
-  /**
    * A symbolic alias for `zipParLeft`.
    */
   final def <&[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, A] =
@@ -97,6 +91,12 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
     zipPar(that)
 
   /**
+   * A symbolic alias for `zipRight`.
+   */
+  final def *>[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, B] =
+    zipRight(that)
+
+  /**
    * A symbolic alias for `zipLeft`.
    */
   final def <*[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, A] =
@@ -110,6 +110,27 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
     trace: Trace
   ): ZQuery[R1, E1, zippable.Out] =
     zip(that)
+
+  /**
+   * A symbolic alias for `zipBatchedRight`.
+   */
+  final def ~>[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, B] =
+    zipBatchedRight(that)
+
+  /**
+   * A symbolic alias for `zipBatchedLeft`.
+   */
+  final def <~[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, A] =
+    zipBatchedLeft(that)
+
+  /**
+   * A symbolic alias for `zipBatched`.
+   */
+  final def <~>[R1 <: R, E1 >: E, B](that: => ZQuery[R1, E1, B])(implicit
+    zippable: Zippable[A, B],
+    trace: Trace
+  ): ZQuery[R1, E1, zippable.Out] =
+    zipBatched(that)
 
   /**
    * Returns a query which submerges the error case of `Either` into the error
@@ -1168,7 +1189,7 @@ object ZQuery {
     mode: Int // 0 = sequential, 1 = parallel, 2 = batched
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): Result[R, E, Collection[B]] = {
 
-    def addToArray(array: Array[B])(idxs: Chunk[RuntimeFlags], values: Chunk[B]): Unit =
+    def addToArray(array: Array[B])(idxs: Chunk[Int], values: Chunk[B]): Unit =
       if (idxs.nonEmpty) {
         var i       = 0
         val iter    = values.chunkIterator
@@ -1321,6 +1342,10 @@ object ZQuery {
    * a `QueryFailure` when run if the data source does not provide results for
    * all requests received. Queries must be constructed with `fromRequest` or
    * one of its variants for optimizations to be applied.
+   *
+   * @see
+   *   [[fromRequests]] for variants that allow for multiple requests to be
+   *   submitted at once
    */
   def fromRequest[R, E, A, B](
     request0: => A
@@ -1329,34 +1354,10 @@ object ZQuery {
       ZQuery.cachingEnabled.getWith { isCachingEnabled =>
         val request    = request0
         val dataSource = dataSource0
-        if (isCachingEnabled) {
-          def foldPromise(either: Either[Promise[E, B], Promise[E, B]]): UIO[Result[R, E, B]] = either match {
-            case Left(promise) =>
-              ZIO.succeed(
-                Result.blocked(
-                  BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
-                  Continue(promise)
-                )
-              )
-            case Right(promise) =>
-              promise.poll.flatMap {
-                case None     => ZIO.succeed(Result.blocked(BlockedRequests.empty, Continue(promise)))
-                case Some(io) => io.exit.map(Result.fromExit)
-              }
-          }
-          ZQuery.currentCache.getWith {
-            case cache: Cache.Default => foldPromise(cache.lookupUnsafe(request)(Unsafe.unsafe))
-            case cache                => cache.lookup(request).flatMap(foldPromise)
-          }
-        } else {
-          ZIO.succeed {
-            val promise = Promise.unsafe.make[E, B](FiberId.None)(Unsafe.unsafe)
-            Result.blocked(
-              BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
-              Continue(promise)
-            )
-          }
-        }
+        if (isCachingEnabled)
+          ZQuery.currentCache.getWith(cachedResult(_, dataSource, request).toZIO)
+        else
+          uncachedResult(dataSource, request)
       }
     }
 
@@ -1367,7 +1368,116 @@ object ZQuery {
   def fromRequestUncached[R, E, A, B](
     request: => A
   )(dataSource: => DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
-    fromRequest(request)(dataSource).uncached
+    new ZQuery(uncachedResult(dataSource, request)).uncached
+
+  /**
+   * Constructs a query from a Chunk of requests and a data source. Queries will
+   * die with a QueryFailure when run the data source does not provide results
+   * for all requests received.
+   *
+   * @see
+   *   [[fromRequest]] for submitting a single request to a datasource
+   * @see
+   *   [[fromRequestsWith]] for a variant that allows transforming the input to
+   *   a request
+   */
+  def fromRequests[R, E, A, B](
+    requests: Chunk[A]
+  )(dataSource: DataSource[R, A])(implicit trace: Trace, ev: A <:< Request[E, B]): ZQuery[R, E, Chunk[B]] =
+    fromRequestsWith(requests, ZIO.identityFn[A])(dataSource)
+
+  /**
+   * Constructs a query from a List of requests and a data source. Queries will
+   * die with a QueryFailure when run the data source does not provide results
+   * for all requests received.
+   *
+   * @see
+   *   [[fromRequest]] for submitting a single request to a datasource
+   * @see
+   *   [[fromRequestsWith]] for a variant that allows transforming the input to
+   *   a request
+   */
+  def fromRequests[R, E, A, B](
+    requests: List[A]
+  )(dataSource: DataSource[R, A])(implicit trace: Trace, ev: A <:< Request[E, B]): ZQuery[R, E, List[B]] =
+    fromRequestsWith(requests, ZIO.identityFn[A])(dataSource)
+
+  /**
+   * Constructs a query from a Chunk of values, a function transforming them
+   * into requests and a data source. Queries will die with a QueryFailure when
+   * run the data source does not provide results for all requests received.
+   */
+  def fromRequestsWith[R, E, In, A, B](
+    as: Chunk[In],
+    f: In => A
+  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, Chunk[B]] =
+    ZQuery {
+      ZQuery.cachingEnabled.getWith {
+        if (_) {
+          ZQuery.currentCache.getWith(cache => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r))))
+        } else {
+          ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
+        }
+      }.map(collectResults(as, _, mode = 2))
+    }
+
+  /**
+   * Constructs a query from a List of values, a function transforming them into
+   * requests and a data source. Queries will die with a QueryFailure when run
+   * the data source does not provide results for all requests received.
+   */
+  def fromRequestsWith[R, E, In, A, B](
+    as: List[In],
+    f: In => A
+  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, List[B]] =
+    ZQuery {
+      ZQuery.cachingEnabled.getWith {
+        if (_) {
+          ZQuery.currentCache.getWith(cache => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r))))
+        } else {
+          ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
+        }
+      }.map(collectResults(as, _, mode = 2))
+    }
+
+  private def cachedResult[R, E, A, B](
+    cache: Cache,
+    dataSource: DataSource[R, A],
+    request: A
+  )(implicit ev: A <:< Request[E, B], trace: Trace): CachedResult[R, E, B] = {
+
+    def foldPromise(either: Either[Promise[E, B], Promise[E, B]]): CachedResult[R, E, B] =
+      either match {
+        case Left(promise) =>
+          CachedResult.Pure(
+            Result.blocked(
+              BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
+              Continue(promise)
+            )
+          )
+        case Right(promise) =>
+          CachedResult.Effectful(promise.poll.flatMap {
+            case None     => ZIO.succeed(Result.blocked(BlockedRequests.empty, Continue(promise)))
+            case Some(io) => io.exit.map(Result.fromExit)
+          })
+      }
+
+    cache match {
+      case cache: Cache.Default => foldPromise(cache.lookupUnsafe(request)(Unsafe.unsafe))
+      case cache                => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
+    }
+  }
+
+  private def uncachedResult[R, E, A, B](dataSource: DataSource[R, A], request: A)(implicit
+    ev: A <:< Request[E, B],
+    trace: Trace
+  ): UIO[Result[R, E, B]] = Exit.succeed {
+    val promise = Promise.unsafe.make[E, B](FiberId.None)(Unsafe.unsafe)
+    Result.blocked(
+      BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
+      Continue(promise)
+    )
+  }
 
   /**
    * Constructs a query from an effect.
@@ -1658,4 +1768,82 @@ object ZQuery {
         }
       }
   }
+
+  /**
+   * The `CachedResult` represents a cache entry that can either be extracted
+   * purely, or that it requires an effect to be run to obtain the result.
+   */
+  private sealed abstract class CachedResult[R, E, A] { self =>
+    def toZIO: UIO[Result[R, E, A]]
+  }
+
+  private object CachedResult {
+
+    def foreach[R, E, A, B, Collection[+x] <: Iterable[x]](
+      as: Collection[A]
+    )(
+      f: A => CachedResult[R, E, B]
+    )(implicit
+      trace: Trace,
+      bf1: BuildFrom[Collection[?], Result[R, E, B], Collection[Result[R, E, B]]],
+      bf2: BuildFrom[Collection[?], UIO[Result[R, E, B]], Collection[UIO[Result[R, E, B]]]]
+    ): UIO[Collection[Result[R, E, B]]] = ZIO.suspendSucceed {
+      val size    = as.size
+      val puresB  = bf1.newBuilder(as)
+      val pureIdx = new ChunkBuilder.Int
+      pureIdx.sizeHint(size)
+
+      val effectfulB   = bf2.newBuilder(as)
+      val effectfulIdx = new ChunkBuilder.Int
+
+      val iter = as.iterator
+      var i    = 0
+      while (iter.hasNext) {
+        val next = f(iter.next())
+        next match {
+          case Pure(result) =>
+            puresB.addOne(result)
+            pureIdx.addOne(i)
+          case Effectful(io) =>
+            effectfulB.addOne(io)
+            effectfulIdx.addOne(i)
+        }
+        i += 1
+      }
+
+      val pures     = puresB.result()
+      val effectful = effectfulB.result()
+
+      if (effectful.isEmpty) ZIO.succeed(pures)
+      else if (pures.isEmpty) ZIO.collectAll(effectful)
+      else {
+        val pIdxs = pureIdx.result()
+        val eIdxs = effectfulIdx.result()
+        ZIO.collectAll(effectful).map { effectful =>
+          val arr = Array.ofDim[Result[R, E, B]](pIdxs.size + eIdxs.size)
+
+          def addToArray(idxs: Chunk[Int], values: Iterable[Result[R, E, B]]): Unit = {
+            val iter    = values.iterator
+            val idxIter = idxs.iterator
+            while (idxIter.hasNext) {
+              val idx   = idxIter.next()
+              val value = iter.next()
+              arr(idx) = value
+            }
+          }
+
+          addToArray(pIdxs, pures)
+          addToArray(eIdxs, effectful)
+          bf1.fromSpecific(as)(arr)
+        }
+      }
+    }
+
+    final case class Pure[R, E, B](result: Result[R, E, B]) extends CachedResult[R, E, B] {
+      def toZIO: UIO[Result[R, E, B]] = Exit.succeed(result)
+    }
+
+    final case class Effectful[R, E, B](toZIO: UIO[Result[R, E, B]]) extends CachedResult[R, E, B]
+  }
+
 }

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -94,12 +94,12 @@ object ZQuerySpec extends ZIOBaseSpec {
           val query = Cache.getAll *> Cache.put(0, 1) *> Cache.getAll
           assertZIO(query.uncached.run)(equalTo(Map(0 -> 1)))
         } @@ nonFlaky
-      ).provideCustom(Cache.live),
+      ).provide(Cache.live),
       suite("zipBatched")(
         test("queries to multiple data sources can be executed in parallel") {
           for {
             promise <- Promise.make[Nothing, Unit]
-            _       <- (neverQuery.zipBatched(succeedQuery(promise))).run.fork
+            _       <- (neverQuery <~> succeedQuery(promise)).run.fork
             _       <- promise.await
           } yield assertCompletes
         },
@@ -108,7 +108,7 @@ object ZQuerySpec extends ZIOBaseSpec {
             ref    <- Ref.make(List.empty[Int])
             query1  = ZQuery.fromZIO(ref.update(1 :: _))
             query2  = ZQuery.fromZIO(ref.update(2 :: _))
-            _      <- (query1.zipBatchedRight(query2)).run
+            _      <- (query1 ~> query2).run
             result <- ref.get
           } yield assert(result)(equalTo(List(2, 1)))
         } @@ nonFlaky
@@ -346,17 +346,16 @@ object ZQuerySpec extends ZIOBaseSpec {
 
   val UserRequestDataSource: DataSource[Any, UserRequest[_]] =
     DataSource.Batched.make[Any, UserRequest[_]]("UserRequestDataSource") { requests =>
-      ZIO.when(requests.toSet.size != requests.size)(ZIO.dieMessage("Duplicate requests)")) *>
-        Console.printLine(requests.toString).orDie *>
-        ZIO.succeed {
-          requests.foldLeft(CompletedRequestMap.empty) {
-            case (completedRequests, GetAllIds) => completedRequests.insert(GetAllIds, Exit.succeed(userIds))
-            case (completedRequests, GetNameById(id)) =>
-              userNames
-                .get(id)
-                .fold(completedRequests)(name => completedRequests.insert(GetNameById(id), Exit.succeed(name)))
-          }
+      (ZIO.when(requests.toSet.size != requests.size)(ZIO.dieMessage("Duplicate requests)")) *>
+        Console.printLine(requests.toString).orDie).as {
+        requests.foldLeft(CompletedRequestMap.empty) {
+          case (completedRequests, GetAllIds) => completedRequests.insert(GetAllIds, Exit.succeed(userIds))
+          case (completedRequests, GetNameById(id)) =>
+            userNames
+              .get(id)
+              .fold(completedRequests)(name => completedRequests.insert(GetNameById(id), Exit.succeed(name)))
         }
+      }
     }
 
   val getAllUserIds: ZQuery[Any, Nothing, List[Int]] =
@@ -368,17 +367,17 @@ object ZQuerySpec extends ZIOBaseSpec {
   val getAllUserNames: ZQuery[Any, Nothing, List[String]] =
     for {
       userIds   <- getAllUserIds
-      userNames <- ZQuery.foreachPar(userIds)(getUserNameById)
+      userNames <- ZQuery.fromRequestsWith(userIds, GetNameById.apply)(UserRequestDataSource)
     } yield userNames
 
   case object GetFoo extends Request[Nothing, String]
   val getFoo: ZQuery[Any, Nothing, String] = ZQuery.fromRequest(GetFoo)(
-    DataSource.fromFunctionZIO("foo")(_ => Console.printLine("Running foo query").orDie *> ZIO.succeed("foo"))
+    DataSource.fromFunctionZIO("foo")(_ => Console.printLine("Running foo query").orDie.as("foo"))
   )
 
   case object GetBar extends Request[Nothing, String]
   val getBar: ZQuery[Any, Nothing, String] = ZQuery.fromRequest(GetBar)(
-    DataSource.fromFunctionZIO("bar")(_ => Console.printLine("Running bar query").orDie *> ZIO.succeed("bar"))
+    DataSource.fromFunctionZIO("bar")(_ => Console.printLine("Running bar query").orDie.as("bar"))
   )
 
   case object NeverRequest extends Request[Nothing, Nothing]

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -367,7 +367,7 @@ object ZQuerySpec extends ZIOBaseSpec {
   val getAllUserNames: ZQuery[Any, Nothing, List[String]] =
     for {
       userIds   <- getAllUserIds
-      userNames <- ZQuery.fromRequestsWith(userIds, GetNameById.apply)(UserRequestDataSource)
+      userNames <- ZQuery.fromRequestsWith(userIds, GetNameById(_))(UserRequestDataSource)
     } yield userNames
 
   case object GetFoo extends Request[Nothing, String]


### PR DESCRIPTION
This PR adds a few extra constructors in order to improve UX and performance.

1. `ZQuery.fromRequests`: Allows for users to create a ZQuery from a Chunk / List of requests
2. `ZQuery.fromRequestsWith`: Variant of (1) which allows users to specify a function to map the input values to a request. This is very useful for cases where we want to avoid mapping e.g., UUIDs to `Req(id: UUID)`
3. Added aliases for
i. `zipRightBatched`: `~>`
ii. `zipLeftBatched`: `<~`
iii. `zipBatched`: `<~>`
4. Added the `query` and `queryAll` methods to `DataSource` so that users can construct queries like: `ds.query(req)` instead of `ZQuery.fromRequest(req)(ds)`

Regarding (1). I wanted to make these methods take generic iterables, but unfortunately I wasn't able to get all the implicit `BuildFrom` to play nicely :( Instead, I created 2 overloads, 1 for `Chunk` and another for `List`, which I believe should be the most common collections that users would use

Note that creating queries via (1) is roughly ~2x faster than creating them individually 🚀 