### PR TITLE
Remove unused type param from `Cache#lookup`

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/Cache.scala
+++ b/zio-query/shared/src/main/scala/zio/query/Cache.scala
@@ -42,7 +42,7 @@ trait Cache {
    * the request is in the cache returns a `Right` with a `Promise` that will
    * contain the result of the request when it is executed.
    */
-  def lookup[R, E, A, B](request: A)(implicit
+  def lookup[E, A, B](request: A)(implicit
     ev: A <:< Request[E, B],
     trace: Trace
   ): UIO[Either[Promise[E, B], Promise[E, B]]]
@@ -79,10 +79,10 @@ object Cache {
     def get[E, A](request: Request[E, A])(implicit trace: Trace): IO[Unit, Promise[E, A]] =
       ZIO.suspendSucceed {
         val out = map.get(request).asInstanceOf[Promise[E, A]]
-        if (out eq null) ZIO.fail(()) else ZIO.succeed(out)
+        if (out eq null) Exit.fail(()) else Exit.succeed(out)
       }
 
-    def lookup[R, E, A, B](request: A)(implicit
+    def lookup[E, A, B](request: A)(implicit
       ev: A <:< Request[E, B],
       trace: Trace
     ): UIO[Either[Promise[E, B], Promise[E, B]]] =


### PR DESCRIPTION
This change is not source-compatible but it's binary compatible. Users creating a custom cache will only need to remove the R type param from the method definition