### PR TITLE
Requests should be cached on a per-datasource level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val docs = project
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-lazy val enforceMimaCompatibility = true // Enable / disable failing CI on binary incompatibilities
+lazy val enforceMimaCompatibility = false // Enable / disable failing CI on binary incompatibilities
 
 lazy val enableMimaSettingsJVM =
   Def.settings(

--- a/zio-query/shared/src/main/scala/zio/query/Cache.scala
+++ b/zio-query/shared/src/main/scala/zio/query/Cache.scala
@@ -82,6 +82,7 @@ abstract class Cache {
 }
 
 object Cache {
+
   /**
    * Constructs an empty cache.
    */

--- a/zio-query/shared/src/main/scala/zio/query/DataSource.scala
+++ b/zio-query/shared/src/main/scala/zio/query/DataSource.scala
@@ -40,7 +40,7 @@ import zio.{Chunk, Exit, Trace, ZEnvironment, ZIO}
  * for all requests received. Failure to do so will cause a query to die with a
  * `QueryFailure` when run.
  */
-trait DataSource[-R, -A] { self =>
+trait DataSource[-R, -A] extends Serializable { self =>
 
   /**
    * Syntax for adding aspects.
@@ -65,7 +65,7 @@ trait DataSource[-R, -A] { self =>
    */
   def batchN(n: Int): DataSource[R, A] =
     new DataSource[R, A] {
-      val identifier = s"${self}.batchN($n)"
+      val identifier = s"$self.batchN($n)"
       def runAll(requests: Chunk[Chunk[A]])(implicit trace: Trace): ZIO[R, Nothing, CompletedRequestMap] =
         if (n < 1)
           ZIO.die(new IllegalArgumentException("batchN: n must be at least 1"))

--- a/zio-query/shared/src/main/scala/zio/query/Request.scala
+++ b/zio-query/shared/src/main/scala/zio/query/Request.scala
@@ -30,4 +30,4 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  *
  * }}}
  */
-trait Request[E, A]
+trait Request[E, A] extends Product with Serializable

--- a/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
+++ b/zio-query/shared/src/test/scala/zio/query/ZQuerySpec.scala
@@ -18,13 +18,14 @@ object ZQuerySpec extends ZIOBaseSpec {
       },
       test("N + 1 on composed queries") {
         for {
-          ref   <- Ref.make(0)
-          ds     = countingDs(ref)
-          query1 = identityDs.query(IdReq(1)).flatMap(i => ds.query(CountingReq(i)))
-          query2 = identityDs.query(IdReq(2)).flatMap(i => ds.query(CountingReq(i)))
-          res   <- (query1 <~> query2).run
-          i     <- ref.get
-        } yield assertTrue(i == 1, res == ("1", "2"))
+          ref     <- Ref.make(0)
+          ds       = countingDs(ref)
+          query1   = identityDs.query(IdReq(1)).flatMap(i => ds.query(CountingReq(i)))
+          query2   = identityDs.query(IdReq(2)).flatMap(i => ds.query(CountingReq(i)))
+          res     <- (query1 <~> query2).run
+          i       <- ref.get
+          expected = ("1", "2")
+        } yield assertTrue(i == 1, res == expected)
       },
       test("requests are cached per datasource") {
         for {


### PR DESCRIPTION
There is a rather annoying bug/issue currently with how we dedup/cache queries. The current Cache takes into consideration only the `Request`, but not the `DataSource`. This means that if a `Request` is reused across different `DataSource`s.

For most usecases this _shouldn't_ be a problem, because having multiple `DataSource`s returning the same type is unlikely. However, this is something that has happened to me before and failed to realise until it hit prod:

```scala
  case class EntityId(id: Int) extends Request[Nothing, Boolean]

  val userExistsDs: DataSource[Any, EntityId] =
    DataSource.fromFunctionBatchedZIO[Any, Nothing, EntityId, Boolean]("UserExistsDS") { requests =>
      ???
    }

  val organisationExistsDs: DataSource[Any, EntityId] =
    DataSource.fromFunctionBatchedZIO[Any, Nothing, EntityId, Boolean]("OrganizationExistsDs") { requests =>
      ???
    }
```
In this case, if we execute a query against both datasources where the `id` exists in both of them, we would be retrieving the result from the cache even if the request was meant for a different datasource.

While the workaround is simple (create another case class for the 2nd case class), I personally believe that the existing behaviour is not correct. If I'm executing a request against a specific DataSource, I expect it to be cached on the datasource that I am making a request against.

Unfortunately, the only way to fix this is by breaking the Cache API by adding DataSource as a parameter to its methods. @paulpdaniels AFAICT you were the one that asked for the Cache to be made abstract, do you see any issues with this? (assuming you ended up using a custom Cache, otherwise ignore me 😅)