### PR TITLE
Use a single `FiberRef` for retrieving the Cache and identifying disabled caching

### DIFF
--- a/benchmarks/src/main/scala/zio/query/DataSourceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/query/DataSourceBenchmark.scala
@@ -55,6 +55,7 @@ class DataSourceBenchmark {
   @Benchmark
   def fetchSumDuplicatedBenchmark(): Long = {
     import FetchImpl._
+    import fetch.fetchM
     type FIO[A] = Fetch[IO, A]
 
     val reqs  = (0 until count).toList.map(i => fetchPlusOne(1))
@@ -64,6 +65,7 @@ class DataSourceBenchmark {
 
   @Benchmark
   def fetchSumUniqueBenchmark(): Long = {
+    import fetch.fetchM
     import FetchImpl._
     type FIO[A] = Fetch[IO, A]
 
@@ -74,7 +76,7 @@ class DataSourceBenchmark {
 
   object ZQueryImpl {
     case class Req(i: Int) extends Request[Nothing, Int]
-    val ds = DataSource.fromFunctionBatchedZIO("PlusOne") { reqs: Chunk[Req] => ZIO.succeed(reqs.map(_.i + 1)) }
+    val ds = DataSource.fromFunctionBatchedZIO("PlusOne") { (reqs: Chunk[Req]) => ZIO.succeed(reqs.map(_.i + 1)) }
   }
 
   object FetchImpl {

--- a/benchmarks/src/main/scala/zio/query/FromRequestBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/query/FromRequestBenchmark.scala
@@ -69,5 +69,5 @@ class FromRequestBenchmark {
   }
 
   private case class Req(i: Int) extends Request[Nothing, Int]
-  private val ds = DataSource.fromFunctionBatchedZIO("Datasource") { reqs: Chunk[Req] => ZIO.succeed(reqs.map(_.i)) }
+  private val ds = DataSource.fromFunctionBatchedZIO("Datasource")((reqs: Chunk[Req]) => ZIO.succeed(reqs.map(_.i)))
 }

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -545,7 +545,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
         ZIO.uninterruptibleMask { restore =>
           ZIO.withFiberRuntime[R, E, A] { (state, _) =>
             val scope = QueryScope.make()
-            state.setFiberRef(ZQuery.currentCache, cache)
+            state.setFiberRef(ZQuery.currentCache, Some(cache))
             state.setFiberRef(ZQuery.currentScope, scope)
             restore(runToZIO).exitWith { exit =>
               state.deleteFiberRef(ZQuery.currentCache)
@@ -1460,8 +1460,8 @@ object ZQuery {
    *   submitted at once
    */
   def fromRequest[R, E, A, B](
-    request0: A
-  )(dataSource0: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
+    request0: => A
+  )(dataSource0: => DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
     ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => cachedResult(cache, dataSource0, request0).toZIO
@@ -1474,8 +1474,8 @@ object ZQuery {
    * caching to the query.
    */
   def fromRequestUncached[R, E, A, B](
-    request: A
-  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
+    request: => A
+  )(dataSource: => DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
     new ZQuery(uncachedResult(dataSource, request)).uncached
 
   /**
@@ -1826,6 +1826,10 @@ object ZQuery {
     }
     (bs.result(), cs.result())
   }
+
+  @deprecated("No longer used, kept for binary compatibility only", "0.7.4")
+  val cachingEnabled: FiberRef[Boolean] =
+    FiberRef.unsafe.make(true)(Unsafe.unsafe)
 
   val currentCache: FiberRef[Option[Cache]] =
     FiberRef.unsafe.make(Option.empty[Cache])(Unsafe.unsafe)

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -187,7 +187,13 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
    *   [[memoize]] for memoizing the result of a single query
    */
   def cached(implicit trace: Trace): ZQuery[R, E, A] =
-    ZQuery.acquireReleaseWith(ZQuery.cachingEnabled.getAndSet(true))(ZQuery.cachingEnabled.set)(_ => self)
+    ZQuery.unwrap(ZQuery.disabledCache.get.map {
+      case None => self
+      case s =>
+        val acq = ZQuery.disabledCache.set(None) *> ZQuery.currentCache.set(s)
+        val rel = ZQuery.disabledCache.set(s) *> ZQuery.currentCache.set(None)
+        ZQuery.acquireReleaseWith(acq)(_ => rel)(_ => self)
+    })
 
   /**
    * Recovers from all errors.
@@ -541,7 +547,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
         } { (scope: Scope.Closeable, exit: Exit[E, A]) =>
           scope.close(exit)
         } { scope =>
-          ZQuery.currentScope.locally(scope)(ZQuery.currentCache.locally(cache)(runToZIO))
+          ZQuery.currentScope.locally(scope)(ZQuery.currentCache.locally(Some(cache))(runToZIO))
         }
       case exit => exit
     }
@@ -675,7 +681,13 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
    * Disables caching for this query.
    */
   def uncached(implicit trace: Trace): ZQuery[R, E, A] =
-    ZQuery.acquireReleaseWith(ZQuery.cachingEnabled.getAndSet(false))(ZQuery.cachingEnabled.set)(_ => self)
+    ZQuery.unwrap(ZQuery.currentCache.get.map {
+      case None => self
+      case s =>
+        val acq = ZQuery.disabledCache.set(s) *> ZQuery.currentCache.set(None)
+        val rel = ZQuery.disabledCache.set(None) *> ZQuery.currentCache.set(s)
+        ZQuery.acquireReleaseWith(acq)(_ => rel)(_ => self)
+    })
 
   /**
    * Converts a `ZQuery[R, Either[E, B], A]` into a `ZQuery[R, E, Either[A,
@@ -1443,16 +1455,12 @@ object ZQuery {
    *   submitted at once
    */
   def fromRequest[R, E, A, B](
-    request0: => A
-  )(dataSource0: => DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
+    request0: A
+  )(dataSource0: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
     ZQuery {
-      ZQuery.cachingEnabled.getWith { isCachingEnabled =>
-        val request    = request0
-        val dataSource = dataSource0
-        if (isCachingEnabled)
-          ZQuery.currentCache.getWith(cachedResult(_, dataSource, request).toZIO)
-        else
-          uncachedResult(dataSource, request)
+      ZQuery.currentCache.getWith {
+        case Some(cache) => cachedResult(cache, dataSource0, request0).toZIO
+        case _           => uncachedResult(dataSource0, request0)
       }
     }
 
@@ -1461,8 +1469,8 @@ object ZQuery {
    * caching to the query.
    */
   def fromRequestUncached[R, E, A, B](
-    request: => A
-  )(dataSource: => DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
+    request: A
+  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, B] =
     new ZQuery(uncachedResult(dataSource, request)).uncached
 
   /**
@@ -1507,12 +1515,9 @@ object ZQuery {
     f: In => A
   )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, Chunk[B]] =
     ZQuery {
-      ZQuery.cachingEnabled.getWith {
-        if (_) {
-          ZQuery.currentCache.getWith(cache => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r))))
-        } else {
-          ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
-        }
+      ZQuery.currentCache.getWith {
+        case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
+        case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
       }.map(collectResults(as, _, mode = 2))
     }
 
@@ -1526,12 +1531,9 @@ object ZQuery {
     f: In => A
   )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, List[B]] =
     ZQuery {
-      ZQuery.cachingEnabled.getWith {
-        if (_) {
-          ZQuery.currentCache.getWith(cache => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r))))
-        } else {
-          ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
-        }
+      ZQuery.currentCache.getWith {
+        case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
+        case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
       }.map(collectResults(as, _, mode = 2))
     }
 
@@ -1820,11 +1822,11 @@ object ZQuery {
     (bs.result(), cs.result())
   }
 
-  val cachingEnabled: FiberRef[Boolean] =
-    FiberRef.unsafe.make(true)(Unsafe.unsafe)
+  val currentCache: FiberRef[Option[Cache]] =
+    FiberRef.unsafe.make(Option.empty[Cache])(Unsafe.unsafe)
 
-  val currentCache: FiberRef[Cache] =
-    FiberRef.unsafe.make(Cache.unsafeMake())(Unsafe.unsafe)
+  private val disabledCache: FiberRef[Option[Cache]] =
+    FiberRef.unsafe.make(Option.empty[Cache])(Unsafe.unsafe)
 
   val currentScope: FiberRef[Scope] =
     FiberRef.unsafe.make[Scope](Scope.global)(Unsafe.unsafe)


### PR DESCRIPTION
Currently, we use 2 `FiberRef`s in the hotpath; one for retrieving the cache and another to check whether caching is enabled. Since disabling the cache is not a standard usecase, we can use a single on to represent both (by having the cache FiberRef return a None when caching is disabled). So that we're able to re-enable caching without loss of the cached values, we store the cache in a secondary `FiberRef` whenever it's disabled. Since this is not a common operation, it's much more performant than previously