### PR TITLE
Add abstract `InMemoryCache` and optimize `BlockedRequests`

### DIFF
--- a/zio-query/shared/src/main/scala/zio/query/Cache.scala
+++ b/zio-query/shared/src/main/scala/zio/query/Cache.scala
@@ -79,7 +79,7 @@ object Cache {
    * value. Prefer extending this class when implementing a cache that doesn't
    * perform any IO, such as a cache based on a Map.
    */
-  abstract class InMemory extends Cache {
+  abstract class InMemoryCache extends Cache {
     def getNow[E, A](request: Request[E, A]): Option[Promise[E, A]]
     def lookupNow[E, A](request: Request[E, A]): Either[Promise[E, A], Promise[E, A]]
     def putNow[E, A](request: Request[E, A], result: Promise[E, A]): Unit
@@ -105,7 +105,7 @@ object Cache {
       ZIO.succeed(removeNow(request))
   }
 
-  private final class NonExpiringCache(map: ConcurrentHashMap[Request[_, _], Promise[_, _]]) extends InMemory {
+  private final class NonExpiringCache(map: ConcurrentHashMap[Request[_, _], Promise[_, _]]) extends InMemoryCache {
     private implicit val unsafe: Unsafe = Unsafe.unsafe
 
     def getNow[E, A](request: Request[E, A]): Option[Promise[E, A]] =

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1559,8 +1559,8 @@ object ZQuery {
       }
 
     cache match {
-      case cache: Cache.InMemory => foldPromise(cache.lookupNow(request))
-      case cache                 => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
+      case cache: Cache.InMemoryCache => foldPromise(cache.lookupNow(request))
+      case cache                      => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
     }
   }
 

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1559,8 +1559,8 @@ object ZQuery {
       }
 
     cache match {
-      case cache: Cache.Synchronous => foldPromise(cache.lookupNow(request))
-      case cache                    => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
+      case cache: Cache.Eager => foldPromise(cache.lookupNow(request))
+      case cache              => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
     }
   }
 

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1559,8 +1559,8 @@ object ZQuery {
       }
 
     cache match {
-      case cache: Cache.Eager => foldPromise(cache.lookupNow(request))
-      case cache              => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
+      case cache: Cache.InMemory => foldPromise(cache.lookupNow(request))
+      case cache                 => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
     }
   }
 

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1559,8 +1559,8 @@ object ZQuery {
       }
 
     cache match {
-      case cache: Cache.Default => foldPromise(cache.lookupUnsafe(request)(Unsafe.unsafe))
-      case cache                => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
+      case cache: Cache.Synchronous => foldPromise(cache.lookupNow(request))
+      case cache                    => CachedResult.Effectful(cache.lookup(request).flatMap(foldPromise(_).toZIO))
     }
   }
 

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -312,7 +312,7 @@ private[query] object BlockedRequests {
     map: mutable.HashMap[Request[_, _], Exit[Any, Any]]
   )(implicit trace: Trace): UIO[Unit] =
     cache match {
-      case cache: Cache.Synchronous =>
+      case cache: Cache.Eager =>
         ZIO.succeedUnsafe { implicit unsafe =>
           map.foreach { case (request: Request[Any, Any], exit) =>
             cache

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -312,7 +312,7 @@ private[query] object BlockedRequests {
     map: mutable.HashMap[Request[_, _], Exit[Any, Any]]
   )(implicit trace: Trace): UIO[Unit] =
     cache match {
-      case cache: Cache.Eager =>
+      case cache: Cache.InMemory =>
         ZIO.succeedUnsafe { implicit unsafe =>
           map.foreach { case (request: Request[Any, Any], exit) =>
             cache

--- a/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/BlockedRequests.scala
@@ -312,7 +312,7 @@ private[query] object BlockedRequests {
     map: mutable.HashMap[Request[_, _], Exit[Any, Any]]
   )(implicit trace: Trace): UIO[Unit] =
     cache match {
-      case cache: Cache.InMemory =>
+      case cache: Cache.InMemoryCache =>
         ZIO.succeedUnsafe { implicit unsafe =>
           map.foreach { case (request: Request[Any, Any], exit) =>
             cache


### PR DESCRIPTION
By adding an abstract `Cache.InMemoryCache`, it allows users to provide Cache implementations that do not require an effect to be evaluated