### PR TITLE
Optimize execution of datasource-backed ZQueries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       run: sbt +publishLocal
     - name: Check binary compatibility
       run: sbt "+zioQueryJVM/mimaReportBinaryIssues; +zioQueryJS/mimaReportBinaryIssues"
+      env:
+        CI_RELEASE_MODE: '1'
     - name: Check website build process
       run: sbt docs/clean; sbt docs/buildWebsite
   lint:
@@ -200,6 +202,7 @@ jobs:
     - name: Release
       run: sbt ci-release
       env:
+        CI_RELEASE_MODE: '1'
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.sbt
+++ b/build.sbt
@@ -3,17 +3,23 @@ import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import zio.sbt.githubactions.*
 
+import scala.collection.immutable.TreeMap
+
 enablePlugins(ZioSbtEcosystemPlugin, ZioSbtCiPlugin)
 
 crossScalaVersions := Seq.empty
 
-lazy val scalaV    = "2.13.14"
+lazy val scala212 = "2.12.19"
+lazy val scala213 = "2.13.14"
+lazy val scala3   = "3.3.3"
+
+lazy val scalaV    = scala213
 lazy val allScalas = List("2.12", "2.13", "3.3")
 
 inThisBuild(
   List(
     name         := "ZIO Query",
-    zioVersion   := "2.1.6",
+    zioVersion   := "2.1.7",
     scalaVersion := scalaV,
     developers := List(
       Developer(
@@ -30,6 +36,18 @@ inThisBuild(
         (zioQueryJVM / thisProject).value.id -> allScalas,
         (zioQueryJS / thisProject).value.id  -> allScalas
       ),
+    ciReleaseJobs :=
+      ciReleaseJobs.value.map { job =>
+        def mapStep(step: Step): Step = step match {
+          case Step.StepSequence(steps) => Step.StepSequence(steps.map(mapStep))
+          case s: Step.SingleStep if s.name.equalsIgnoreCase("Release") =>
+            val newMap = TreeMap.empty[String, String] ++ s.env.updated(ciReleaseModeKey, "1")
+            s.copy(env = newMap)
+          case s => s
+        }
+        val steps = job.steps.map(mapStep)
+        job.copy(steps = steps)
+      },
     versionScheme := Some("early-semver")
   )
 )
@@ -47,15 +65,19 @@ lazy val root = project
   )
 
 lazy val zioQuery = crossProject(JSPlatform, JVMPlatform)
+  .enablePlugins(BuildInfoPlugin)
   .in(file("zio-query"))
   .settings(
+    crossScalaVersions := List(scala212, scala213, scala3),
     stdSettings(
       name = Some("zio-query"),
       packageName = Some("zio.query"),
-      enableCrossProject = true
+      enableCrossProject = true,
+      turnCompilerWarningIntoErrors = true
     )
   )
   .settings(enableZIO())
+  .settings(buildInfoSettings())
   .settings(scalacOptions += "-Wconf:msg=[zio.stacktracer.TracingImplicits.disableAutoTrace]:silent")
   .settings(
     libraryDependencies ++= Seq(
@@ -64,13 +86,15 @@ lazy val zioQuery = crossProject(JSPlatform, JVMPlatform)
     scalacOptions ++=
       (if (scalaBinaryVersion.value == "3")
          Seq()
-       else
+       else {
+
          Seq(
            "-opt:l:method",
            "-opt:l:inline",
            "-opt-inline-from:scala.**",
            "-opt-inline-from:zio.**"
-         ))
+         ) ++ (if (isRelease) Seq("-Xelide-below", "2001") else Seq())
+       })
   )
 
 lazy val zioQueryJS = zioQuery.js
@@ -90,6 +114,9 @@ lazy val zioQueryJVM = zioQuery.jvm.settings(enableMimaSettingsJVM)
 
 lazy val benchmarks = project
   .in(file("benchmarks"))
+  .settings(
+    crossScalaVersions := List(scala213, scala3)
+  )
   .dependsOn(zioQueryJVM)
   .enablePlugins(JmhPlugin)
   .settings(libraryDependencies += "com.47deg" %% "fetch" % "3.1.2")
@@ -130,5 +157,25 @@ lazy val enableMimaSettingsJS =
 ThisBuild / ciCheckArtifactsBuildSteps +=
   Step.SingleStep(
     "Check binary compatibility",
+    env = Map(ciReleaseModeKey -> "1"),
     run = Some("sbt \"+zioQueryJVM/mimaReportBinaryIssues; +zioQueryJS/mimaReportBinaryIssues\"")
+  )
+
+lazy val ciReleaseModeKey = "CI_RELEASE_MODE"
+
+lazy val isRelease = {
+  val value = sys.env.contains(ciReleaseModeKey)
+  if (value) println(s"Detected $ciReleaseModeKey envvar, enabling optimizations")
+  value
+}
+
+def buildInfoSettings() =
+  Seq(
+    buildInfoObject := "BuildUtils",
+    // BuildInfoOption.ConstantValue required to disable assertions in FiberRuntime!
+    buildInfoOptions ++= Seq(BuildInfoOption.ConstantValue, BuildInfoOption.PackagePrivate),
+    buildInfoKeys := Seq(
+      BuildInfoKey("optimizationsEnabled" -> isRelease)
+    ),
+    buildInfoPackage := "zio.query"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,8 @@ lazy val zioQuery = crossProject(JSPlatform, JVMPlatform)
          Seq(
            "-opt:l:method",
            "-opt:l:inline",
-           "-opt-inline-from:scala.**"
+           "-opt-inline-from:scala.**",
+           "-opt-inline-from:zio.**"
          ))
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.0
+sbt.version = 1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,8 @@ addSbtPlugin("dev.zio" % "zio-sbt-ecosystem" % zioSbtVersion)
 addSbtPlugin("dev.zio" % "zio-sbt-website"   % zioSbtVersion)
 addSbtPlugin("dev.zio" % "zio-sbt-ci"        % zioSbtVersion)
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage"   % "2.0.12")
-addSbtPlugin("com.typesafe"  % "sbt-mima-plugin" % "1.1.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage"   % "2.1.0")
+addSbtPlugin("com.typesafe"  % "sbt-mima-plugin" % "1.1.4")
+addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"   % "0.12.0")
 
 resolvers ++= Resolver.sonatypeOssRepos("public")

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -21,6 +21,7 @@ import zio.query.internal._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicBoolean
+import scala.annotation.switch
 import scala.collection.compat.{BuildFrom => _, _}
 import scala.collection.mutable.ArrayBuilder
 import scala.reflect.ClassTag
@@ -1163,7 +1164,7 @@ object ZQuery {
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] = {
     implicit val ct1: ClassTag[A] = anyRefClassTag
     implicit val c2: ClassTag[B]  = anyRefClassTag
-    foreachSequentialOuter(as.toArray, mode = 0)(f).map(bf.fromSpecific(as)(_))
+    foreachSequentialOuter[R, E, A, B, Collection](as.toArray, mode = 0, bf.fromSpecific(as)(_))(f)
   }
 
   /**
@@ -1188,7 +1189,7 @@ object ZQuery {
   def foreach[R, E, A, B: ClassTag](in: Array[A])(f: A => ZQuery[R, E, B])(implicit
     trace: Trace
   ): ZQuery[R, E, Array[B]] =
-    foreachSequentialOuter(in, mode = 0)(f)
+    foreachSequentialOuter(in, mode = 0, ZIO.identityFn[Array[B]])(f)
 
   /**
    * Applies the function `f` to each element of the `Map[Key, Value]` and
@@ -1235,7 +1236,7 @@ object ZQuery {
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] = {
     implicit val ct1: ClassTag[A] = anyRefClassTag
     implicit val ct2: ClassTag[B] = anyRefClassTag
-    foreachSequentialOuter(as.toArray, mode = 2)(f).map(bf.fromSpecific(as)(_))
+    foreachSequentialOuter[R, E, A, B, Collection](as.toArray, mode = 2, bf.fromSpecific(as)(_))(f)
   }
 
   def foreachBatched[R, E, A, B](as: Set[A])(fn: A => ZQuery[R, E, B])(implicit
@@ -1253,7 +1254,7 @@ object ZQuery {
   def foreachBatched[R, E, A, B: ClassTag](as: Array[A])(f: A => ZQuery[R, E, B])(implicit
     trace: Trace
   ): ZQuery[R, E, Array[B]] =
-    foreachSequentialOuter(as, mode = 2)(f)
+    foreachSequentialOuter(as, mode = 2, ZIO.identityFn[Array[B]])(f)
 
   /**
    * Performs a query for each element in a Map, batching requests to data
@@ -1290,14 +1291,14 @@ object ZQuery {
     f: A => ZQuery[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
     as.sizeCompare(1) match {
-      case -1 => ZQuery.succeedNow(bf.newBuilder(as).result())
+      case -1 => ZQuery.succeedNow(bf.fromSpecific(as)(Nil))
       case 0  => f(as.head).map(v => (bf.newBuilder(as) += v).result())
       case _ =>
         implicit val ct: ClassTag[A] = anyRefClassTag
         ZQuery {
           ZIO
             .foreachPar(as.toArray)(f(_).step)
-            .map(collectResults(_, mode = 1).map(bf.fromSpecific(as)(_)))
+            .map(collectResults[R, E, A, B, Collection](_, mode = 1, bf.fromSpecific(as)(_)))
         }
     }
 
@@ -1431,9 +1432,9 @@ object ZQuery {
   )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, Chunk[B]] =
     ZQuery {
       ZQuery.currentCache.getWith {
-        case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
+        case Some(cache) => CachedResult.foreachAsArr(as)(r => cachedResult(cache, dataSource, f(r)))
         case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
-      }.map(v => collectResults(v, mode = 2).map(Chunk.fromArray))
+      }.map(v => collectResults(v, mode = 2, Chunk.fromArray))
     }
 
   /**
@@ -1447,9 +1448,9 @@ object ZQuery {
   )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B], trace: Trace): ZQuery[R, E, List[B]] =
     ZQuery {
       ZQuery.currentCache.getWith {
-        case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
+        case Some(cache) => CachedResult.foreachAsArr(as)(r => cachedResult(cache, dataSource, f(r)))
         case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
-      }.map(v => collectResults(v, mode = 2).map(_.toList))
+      }.map(v => collectResults(v, mode = 2, _.toList))
     }
 
   private def cachedResult[R, E, A, B](
@@ -1835,16 +1836,18 @@ object ZQuery {
   /**
    * `foreach` base implementation for sequential and batched modes
    */
-  private def foreachSequentialOuter[R, E, A, B](
+  private def foreachSequentialOuter[R, E, A, B, F[_]](
     as: Array[A],
-    mode: Int // 0 or 2
+    mode: Int, // 0 or 2
+    mapOut: Array[B] => F[B]
   )(
     f: A => ZQuery[R, E, B]
-  )(implicit trace: Trace, ct: ClassTag[B]): ZQuery[R, E, Array[B]] = {
-    assert(mode != 1)
+  )(implicit trace: Trace, ct: ClassTag[B]): ZQuery[R, E, F[B]] = {
+    assert(BuildUtils.optimizationsEnabled || mode != 1)
+
     as.length match {
-      case 0 => ZQuery.succeedNow(Array.empty[B])
-      case 1 => f(as.head).map(v => Array(v))
+      case 0 => ZQuery.succeedNow(mapOut(Array.empty[B]))
+      case 1 => f(as.head).map(v => mapOut(Array(v)))
       case n =>
         ZQuery {
           ZIO.suspendSucceed {
@@ -1853,7 +1856,7 @@ object ZQuery {
 
             ZIO
               .whileLoop(i < n)(f(as(i)).step) { v => arr(i) = v; i += 1 }
-              .as(collectResults(arr, mode))
+              .as(collectResults(arr, mode, mapOut))
           }
         }
     }
@@ -1870,10 +1873,11 @@ object ZQuery {
     ZIO.whileLoop(i < size)(in(i)) { v => out(i) = v; i += 1 }.as(out)
   }
 
-  private def collectResults[R, E, A, B](
+  private def collectResults[R, E, A, B, F[_]](
     results: Array[Result[R, E, B]],
-    mode: Int // 0 = sequential, 1 = parallel, 2 = batched
-  )(implicit trace: Trace): Result[R, E, Array[B]] = {
+    mode: Int, // 0 = sequential, 1 = parallel, 2 = batched
+    mapOut: Array[B] => F[B]
+  )(implicit trace: Trace): Result[R, E, F[B]] = {
     implicit val classTag: ClassTag[B] = anyRefClassTag
 
     @inline def addToArray(array: Array[B])(idxs: Array[Int], values: Array[B]): Unit = {
@@ -1950,7 +1954,7 @@ object ZQuery {
     val fails = failBuilder.result()
 
     if (gets.isEmpty && effects.isEmpty && fails.isEmpty)
-      Result.done(dones)
+      Result.done(mapOut(dones))
     else if (fails.isEmpty) {
       val continue =
         if (effects.isEmpty) {
@@ -1958,14 +1962,14 @@ object ZQuery {
             val array = Array.ofDim[B](size)
             addToArray(array)(getIndices, gets)
             addToArray(array)(doneIndices, dones)
-            array
+            mapOut(array)
           }
           Continue.get(io)
         } else {
-          val collect = mode match {
-            case 0 => ZQuery.collectAll(effects)
-            case 1 => ZQuery.collectAllPar(effects)
-            case 2 => ZQuery.collectAllBatched(effects)
+          val collect = (mode: @switch) match {
+            case 0 => ZQuery.collectAll[R, E, B](effects)
+            case 1 => ZQuery.collectAllPar[R, E, B](effects)
+            case 2 => ZQuery.collectAllBatched[R, E, B](effects)
           }
           val query = collect.mapZIO { effects =>
             collectArrayZIO(gets).map { gets =>
@@ -1973,7 +1977,7 @@ object ZQuery {
               addToArray(array)(effectIndices, effects)
               addToArray(array)(getIndices, gets)
               addToArray(array)(doneIndices, dones)
-              array
+              mapOut(array)
             }
           }
           Continue.effect(query)
@@ -1999,8 +2003,19 @@ object ZQuery {
 
     final case class Effectful[R, E, B](toZIO: UIO[Result[R, E, B]]) extends CachedResult[R, E, B]
 
+    @deprecated("Kept for bin-compat, use `foreachAsArr` instead", "0.7.5")
     def foreach[R, E, A, B, Collection[+x] <: Iterable[x]](
       as: Collection[A]
+    )(
+      f: A => CachedResult[R, E, B]
+    )(implicit
+      trace: Trace,
+      bf: BuildFrom[Collection[A], Result[R, E, B], Collection[Result[R, E, B]]]
+    ): UIO[Collection[Result[R, E, B]]] =
+      foreachAsArr(as)(f).map(bf.fromSpecific(as)(_))
+
+    def foreachAsArr[R, E, A, B](
+      as: Iterable[A]
     )(
       f: A => CachedResult[R, E, B]
     )(implicit

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1865,10 +1865,9 @@ object ZQuery {
   @inline private def collectArrayZIO[R, E, A: ClassTag](
     in: Array[ZIO[R, E, A]]
   )(implicit trace: Trace): ZIO[R, E, Array[A]] = {
-    val iterator = in.iterator
-    val out      = Array.ofDim[A](in.length)
-    val size     = in.length
-    var i        = 0
+    val size = in.length
+    val out  = Array.ofDim[A](size)
+    var i    = 0
 
     ZIO.whileLoop(i < size)(in(i)) { v => out(i) = v; i += 1 }.as(out)
   }
@@ -1890,9 +1889,8 @@ object ZQuery {
       }
     }
 
-    var i                             = 0
-    val size                          = results.length
-    var doneSize, effectSize, getSize = 0
+    val size                             = results.length
+    var i, doneSize, effectSize, getSize = 0
 
     // 2-pass to pre-size arrays. Benchmarks show that this is faster than a single-pass using unsized builders
     while (i < size) {

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1160,8 +1160,11 @@ object ZQuery {
     as: Collection[A]
   )(
     f: A => ZQuery[R, E, B]
-  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    foreachSequentialOuter(as, mode = 0)(f)
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] = {
+    implicit val ct1: ClassTag[A] = anyRefClassTag
+    implicit val c2: ClassTag[B]  = anyRefClassTag
+    foreachSequentialOuter(as.toArray, mode = 0)(f).map(bf.fromSpecific(as)(_))
+  }
 
   /**
    * Applies the function `f` to each element of the `Set[A]` and returns the
@@ -1185,7 +1188,7 @@ object ZQuery {
   def foreach[R, E, A, B: ClassTag](in: Array[A])(f: A => ZQuery[R, E, B])(implicit
     trace: Trace
   ): ZQuery[R, E, Array[B]] =
-    foreach[R, E, A, B, Iterable](in)(f).map(_.toArray)
+    foreachSequentialOuter(in, mode = 0)(f)
 
   /**
    * Applies the function `f` to each element of the `Map[Key, Value]` and
@@ -1229,8 +1232,11 @@ object ZQuery {
     as: Collection[A]
   )(
     f: A => ZQuery[R, E, B]
-  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    foreachSequentialOuter(as, mode = 2)(f)
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] = {
+    implicit val ct1: ClassTag[A] = anyRefClassTag
+    implicit val ct2: ClassTag[B] = anyRefClassTag
+    foreachSequentialOuter(as.toArray, mode = 2)(f).map(bf.fromSpecific(as)(_))
+  }
 
   def foreachBatched[R, E, A, B](as: Set[A])(fn: A => ZQuery[R, E, B])(implicit
     trace: Trace
@@ -1247,7 +1253,7 @@ object ZQuery {
   def foreachBatched[R, E, A, B: ClassTag](as: Array[A])(f: A => ZQuery[R, E, B])(implicit
     trace: Trace
   ): ZQuery[R, E, Array[B]] =
-    foreachBatched[R, E, A, B, Iterable](as)(f).map(_.toArray)
+    foreachSequentialOuter(as, mode = 2)(f)
 
   /**
    * Performs a query for each element in a Map, batching requests to data
@@ -1287,10 +1293,11 @@ object ZQuery {
       case -1 => ZQuery.succeedNow(bf.newBuilder(as).result())
       case 0  => f(as.head).map(v => (bf.newBuilder(as) += v).result())
       case _ =>
+        implicit val ct: ClassTag[A] = anyRefClassTag
         ZQuery {
           ZIO
-            .foreachPar[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
-            .map(v => collectResults(as, v.toArray, mode = 1).map(bf.fromSpecific(as)(_)))
+            .foreachPar(as.toArray)(f(_).step)
+            .map(collectResults(_, mode = 1).map(bf.fromSpecific(as)(_)))
         }
     }
 
@@ -1426,7 +1433,7 @@ object ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
         case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
-      }.map(v => collectResults(as, v, mode = 2).map(Chunk.fromArray))
+      }.map(v => collectResults(v, mode = 2).map(Chunk.fromArray))
     }
 
   /**
@@ -1442,7 +1449,7 @@ object ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
         case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
-      }.map(v => collectResults(as, v, mode = 2).map(_.toList))
+      }.map(v => collectResults(v, mode = 2).map(_.toList))
     }
 
   private def cachedResult[R, E, A, B](
@@ -1822,29 +1829,35 @@ object ZQuery {
       }
   }
 
-  private def foreachSequentialOuter[R, E, A, B, Collection[+Element] <: Iterable[Element]](
-    as: Collection[A],
+  @inline private def anyRefClassTag[A]: ClassTag[A] =
+    ClassTag.AnyRef.asInstanceOf[ClassTag[A]]
+
+  /**
+   * `foreach` base implementation for sequential and batched modes
+   */
+  private def foreachSequentialOuter[R, E, A, B](
+    as: Array[A],
     mode: Int // 0 or 2
   )(
     f: A => ZQuery[R, E, B]
-  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    as.sizeCompare(1) match {
-      case -1 => ZQuery.succeedNow(bf.fromSpecific(as)(Chunk.empty))
-      case 0  => f(as.head).map(v => bf.fromSpecific(as)(Chunk.single(v)))
-      case _ =>
+  )(implicit trace: Trace, ct: ClassTag[B]): ZQuery[R, E, Array[B]] = {
+    assert(mode != 1)
+    as.length match {
+      case 0 => ZQuery.succeedNow(Array.empty[B])
+      case 1 => f(as.head).map(v => Array(v))
+      case n =>
         ZQuery {
           ZIO.suspendSucceed {
-            val arr = new ArrayBuilder.ofRef[Result[R, E, B]]
-            val ks  = as.knownSize
-            if (ks > 0) arr.sizeHint(ks)
-            val it = as.iterator
+            var i   = 0
+            val arr = Array.ofDim[Result[R, E, B]](n)
 
-            ZIO.whileLoop(it.hasNext)(f(it.next()).step)(arr.addOne).as {
-              collectResults(as, arr.result(), mode).map(bf.fromSpecific(as)(_))
-            }
+            ZIO
+              .whileLoop(i < n)(f(as(i)).step) { v => arr(i) = v; i += 1 }
+              .as(collectResults(arr, mode))
           }
         }
     }
+  }
 
   @inline private def collectArrayZIO[R, E, A: ClassTag](
     in: Array[ZIO[R, E, A]]
@@ -1854,15 +1867,14 @@ object ZQuery {
     val size     = in.length
     var i        = 0
 
-    ZIO.whileLoop(i < size)(in(i)) { v => out(i); i += 1 }.as(out)
+    ZIO.whileLoop(i < size)(in(i)) { v => out(i) = v; i += 1 }.as(out)
   }
 
-  private def collectResults[R, E, A, B, Collection[+Element] <: Iterable[Element]](
-    as: Collection[A],
+  private def collectResults[R, E, A, B](
     results: Array[Result[R, E, B]],
     mode: Int // 0 = sequential, 1 = parallel, 2 = batched
   )(implicit trace: Trace): Result[R, E, Array[B]] = {
-    implicit val classTag: ClassTag[B] = ClassTag.AnyRef.asInstanceOf[ClassTag[B]]
+    implicit val classTag: ClassTag[B] = anyRefClassTag
 
     @inline def addToArray(array: Array[B])(idxs: Array[Int], values: Array[B]): Unit = {
       var i = 0
@@ -1927,7 +1939,7 @@ object ZQuery {
         case Result.Done(b) =>
           dones(dIdx) = b
           doneIndices(dIdx) = index
-          gIdx += 1
+          dIdx += 1
           index += 1
         case Result.Fail(e) =>
           failBuilder.addOne(e)

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -1164,7 +1164,7 @@ object ZQuery {
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] = {
     implicit val ct1: ClassTag[A] = anyRefClassTag
     implicit val c2: ClassTag[B]  = anyRefClassTag
-    foreachSequentialOuter[R, E, A, B, Collection](as.toArray, mode = 0, bf.fromSpecific(as)(_))(f)
+    foreachSequentialOuter[R, E, A, B, Collection](as.toArray, mode = Mode.Sequential, bf.fromSpecific(as)(_))(f)
   }
 
   /**
@@ -1189,7 +1189,7 @@ object ZQuery {
   def foreach[R, E, A, B: ClassTag](in: Array[A])(f: A => ZQuery[R, E, B])(implicit
     trace: Trace
   ): ZQuery[R, E, Array[B]] =
-    foreachSequentialOuter(in, mode = 0, ZIO.identityFn[Array[B]])(f)
+    foreachSequentialOuter(in, mode = Mode.Sequential, ZIO.identityFn[Array[B]])(f)
 
   /**
    * Applies the function `f` to each element of the `Map[Key, Value]` and
@@ -1236,7 +1236,7 @@ object ZQuery {
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] = {
     implicit val ct1: ClassTag[A] = anyRefClassTag
     implicit val ct2: ClassTag[B] = anyRefClassTag
-    foreachSequentialOuter[R, E, A, B, Collection](as.toArray, mode = 2, bf.fromSpecific(as)(_))(f)
+    foreachSequentialOuter[R, E, A, B, Collection](as.toArray, mode = Mode.Batched, bf.fromSpecific(as)(_))(f)
   }
 
   def foreachBatched[R, E, A, B](as: Set[A])(fn: A => ZQuery[R, E, B])(implicit
@@ -1254,7 +1254,7 @@ object ZQuery {
   def foreachBatched[R, E, A, B: ClassTag](as: Array[A])(f: A => ZQuery[R, E, B])(implicit
     trace: Trace
   ): ZQuery[R, E, Array[B]] =
-    foreachSequentialOuter(as, mode = 2, ZIO.identityFn[Array[B]])(f)
+    foreachSequentialOuter(as, mode = Mode.Batched, ZIO.identityFn[Array[B]])(f)
 
   /**
    * Performs a query for each element in a Map, batching requests to data
@@ -1298,7 +1298,7 @@ object ZQuery {
         ZQuery {
           ZIO
             .foreachPar(as.toArray)(f(_).step)
-            .map(collectResults[R, E, A, B, Collection](_, mode = 1, bf.fromSpecific(as)(_)))
+            .map(collectResults[R, E, A, B, Collection](_, mode = Mode.Parallel, bf.fromSpecific(as)(_)))
         }
     }
 
@@ -1434,7 +1434,7 @@ object ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => CachedResult.foreachAsArr(as)(r => cachedResult(cache, dataSource, f(r)))
         case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
-      }.map(v => collectResults(v, mode = 2, Chunk.fromArray))
+      }.map(v => collectResults(v, mode = Mode.Batched, Chunk.fromArray))
     }
 
   /**
@@ -1450,7 +1450,7 @@ object ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => CachedResult.foreachAsArr(as)(r => cachedResult(cache, dataSource, f(r)))
         case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
-      }.map(v => collectResults(v, mode = 2, _.toList))
+      }.map(v => collectResults(v, mode = Mode.Batched, _.toList))
     }
 
   private def cachedResult[R, E, A, B](
@@ -1838,12 +1838,12 @@ object ZQuery {
    */
   private def foreachSequentialOuter[R, E, A, B, F[_]](
     as: Array[A],
-    mode: Int, // 0 or 2
+    mode: Mode, // Sequential or Batched
     mapOut: Array[B] => F[B]
   )(
     f: A => ZQuery[R, E, B]
   )(implicit trace: Trace, ct: ClassTag[B]): ZQuery[R, E, F[B]] = {
-    assert(BuildUtils.optimizationsEnabled || mode != 1)
+    assert(BuildUtils.optimizationsEnabled || mode != Mode.Parallel)
 
     as.length match {
       case 0 => ZQuery.succeedNow(mapOut(Array.empty[B]))
@@ -1874,7 +1874,7 @@ object ZQuery {
 
   private def collectResults[R, E, A, B, F[_]](
     results: Array[Result[R, E, B]],
-    mode: Int, // 0 = sequential, 1 = parallel, 2 = batched
+    mode: Mode,
     mapOut: Array[B] => F[B]
   )(implicit trace: Trace): Result[R, E, F[B]] = {
     implicit val classTag: ClassTag[B] = anyRefClassTag
@@ -1965,9 +1965,9 @@ object ZQuery {
           Continue.get(io)
         } else {
           val collect = (mode: @switch) match {
-            case 0 => ZQuery.collectAll[R, E, B](effects)
-            case 1 => ZQuery.collectAllPar[R, E, B](effects)
-            case 2 => ZQuery.collectAllBatched[R, E, B](effects)
+            case Mode.Sequential => ZQuery.collectAll[R, E, B](effects)
+            case Mode.Parallel   => ZQuery.collectAllPar[R, E, B](effects)
+            case Mode.Batched    => ZQuery.collectAllBatched[R, E, B](effects)
           }
           val query = collect.mapZIO { effects =>
             collectArrayZIO(gets).map { gets =>
@@ -2077,5 +2077,12 @@ object ZQuery {
 
   private implicit class IterableOps[A](private val it: Iterable[A]) extends AnyVal {
     def knownSize: Int = it.size
+  }
+
+  private type Mode = Int
+  private object Mode {
+    final val Sequential = 0
+    final val Parallel   = 1
+    final val Batched    = 2
   }
 }

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -237,9 +237,9 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
   def flatMap[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, B] =
     ZQuery {
       step.flatMap {
-        case Result.Blocked(br, c) => Exit.succeed(Result.blocked(br, c.mapQuery(f)))
+        case Result.Blocked(br, c) => Result.blockedExit(br, c.mapQuery(f))
         case Result.Done(a)        => f(a).step
-        case Result.Fail(e)        => Exit.succeed(Result.fail(e))
+        case Result.Fail(e)        => Result.failExit(e)
       }
     }
 
@@ -278,7 +278,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
       step.foldCauseZIO(
         failure(_).step,
         {
-          case Result.Blocked(br, c) => Exit.succeed(Result.blocked(br, c.foldCauseQuery(failure, success)))
+          case Result.Blocked(br, c) => Result.blockedExit(br, c.foldCauseQuery(failure, success))
           case Result.Done(a)        => success(a).step
           case Result.Fail(e)        => failure(e).step
         }
@@ -384,7 +384,13 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
    * Maps the specified effectual function over the result of this query.
    */
   def mapZIO[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B])(implicit trace: Trace): ZQuery[R1, E1, B] =
-    flatMap(a => ZQuery.fromZIONow(f(a)))
+    ZQuery {
+      step.flatMap {
+        case Result.Blocked(br, c) => Result.blockedExit(br, c.mapZIO(f))
+        case Result.Done(a)        => f(a).foldCauseZIO(Result.failExit, Result.doneExit)
+        case f: Result.Fail[E1]    => Exit.succeed(f)
+      }
+    }
 
   /**
    * Converts this query to one that returns `Some` if data sources return
@@ -422,7 +428,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
     ZQuery {
       ZIO.scoped[R0] {
         layer.value.build.exit.flatMap {
-          case Exit.Failure(e) => Exit.succeed(Result.fail(e))
+          case Exit.Failure(e) => Result.failExit(e)
           case Exit.Success(r) => self.provideEnvironment(Described(r, layer.description)).step
         }
       }
@@ -469,11 +475,11 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
           case Result.Blocked(blockedRequests, continue) =>
             continue match {
               case Continue.Effect(query) =>
-                Exit.succeed(Result.blocked(blockedRequests, Continue.effect(race(query, fiber))))
+                Result.blockedExit(blockedRequests, Continue.effect(race(query, fiber)))
               case Continue.Get(io) =>
-                Exit.succeed(Result.blocked(blockedRequests, Continue.effect(race(ZQuery.fromZIONow(io), fiber))))
+                Result.blockedExit(blockedRequests, Continue.effect(race(ZQuery.fromZIONow(io), fiber)))
             }
-          case Result.Done(value) => fiber.interrupt *> Exit.succeed(Result.done(value))
+          case Result.Done(value) => fiber.interrupt *> Result.doneExit(value)
           case Result.Fail(cause) => fiber.join.map(_.mapErrorCause(_ && cause))
         }
       )
@@ -877,7 +883,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
     ZQuery {
       self.step.flatMap {
         case Result.Blocked(br, Continue.Effect(c)) =>
-          Exit.succeed(Result.blocked(br, Continue.effect(c.zipWith(that)(f))))
+          Result.blockedExit(br, Continue.effect(c.zipWith(that)(f)))
         case Result.Blocked(br1, c1) =>
           that.step.map {
             case Result.Blocked(br2, c2) =>
@@ -892,7 +898,7 @@ final class ZQuery[-R, +E, +A] private (private val step: ZIO[R, Nothing, Result
             case Result.Done(b)        => Result.done(f(a, b))
             case Result.Fail(e)        => Result.fail(e)
           }
-        case Result.Fail(e) => Exit.succeed(Result.fail(e))
+        case e: Result.Fail[E1] => Exit.succeed(e)
       }
     }
 
@@ -1142,7 +1148,7 @@ object ZQuery {
    * Eagerly constructs a query that fails with the specified cause.
    */
   def failCauseNow[E](cause: Cause[E]): ZQuery[Any, E, Nothing] =
-    ZQuery(Exit.succeed(Result.fail(cause)))
+    ZQuery(Result.failExit(cause))
 
   /**
    * Performs a query for each element in a collection, collecting the results
@@ -1326,12 +1332,12 @@ object ZQuery {
 
     var blockedRequests: BlockedRequests[R]          = BlockedRequests.empty
     val doneBuilder: ChunkBuilder[B]                 = ChunkBuilder.make[B]()
-    val doneIndicesBuilder: ChunkBuilder[Int]        = new ChunkBuilder.Int
+    val doneIndicesBuilder                           = new ChunkBuilder.Int
     val effectBuilder: ChunkBuilder[ZQuery[R, E, B]] = ChunkBuilder.make[ZQuery[R, E, B]]()
-    val effectIndicesBuilder: ChunkBuilder[Int]      = new ChunkBuilder.Int
+    val effectIndicesBuilder                         = new ChunkBuilder.Int
     val failBuilder: ChunkBuilder[Cause[E]]          = ChunkBuilder.make[Cause[E]]()
-    val getBuilder: ChunkBuilder[IO[E, B]]           = ChunkBuilder.make[IO[E, B]]()
-    val getIndicesBuilder: ChunkBuilder[Int]         = new ChunkBuilder.Int
+    val getBuilder                                   = ChunkBuilder.make[ZIO[R, E, B]]()
+    val getIndicesBuilder                            = new ChunkBuilder.Int
     var index: Int                                   = 0
     val iter                                         = results.iterator
 
@@ -1586,9 +1592,9 @@ object ZQuery {
   private def uncachedResult[R, E, A, B](dataSource: DataSource[R, A], request: A)(implicit
     ev: A <:< Request[E, B],
     trace: Trace
-  ): UIO[Result[R, E, B]] = Exit.succeed {
+  ): UIO[Result[R, E, B]] = {
     val promise = Promise.unsafe.make[E, B](FiberId.None)(Unsafe.unsafe)
-    Result.blocked(
+    Result.blockedExit(
       BlockedRequests.single(dataSource, BlockedRequest(request, promise)),
       Continue(promise)
     )
@@ -1611,7 +1617,7 @@ object ZQuery {
    * users should use [[fromZIO]] instead.
    */
   def fromZIONow[R, E, A](effect: ZIO[R, E, A])(implicit trace: Trace): ZQuery[R, E, A] =
-    ZQuery(effect.foldCauseZIO(c => Exit.succeed(Result.fail(c)), v => Exit.succeed(Result.done(v))))
+    ZQuery(effect.foldCauseZIO(c => Result.failExit(c), v => Result.doneExit(v)))
 
   /**
    * Constructs a query that never completes.
@@ -1695,7 +1701,7 @@ object ZQuery {
    * Eagerly constructs a query that succeeds with the specified value.
    */
   def succeedNow[A](value: A): ZQuery[Any, Nothing, A] =
-    ZQuery(Exit.succeed(Result.done(value)))
+    ZQuery(Result.doneExit(value))
 
   /**
    * Returns a lazily constructed query.
@@ -1744,7 +1750,7 @@ object ZQuery {
 
   final class EnvironmentWithPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: ZEnvironment[R] => A)(implicit trace: Trace): ZQuery[R, Nothing, A] =
-      environment[R].map(f)
+      ZQuery(ZIO.environmentWith[R](e => Result.done(f(e))))
   }
 
   final class EnvironmentWithQueryPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
@@ -1754,7 +1760,14 @@ object ZQuery {
 
   final class EnvironmentWithZIOPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](f: ZEnvironment[R] => ZIO[R, E, A])(implicit trace: Trace): ZQuery[R, E, A] =
-      environment[R].mapZIO(f)
+      ZQuery(
+        ZIO.environmentWithZIO[R](
+          f(_).foldCauseZIO(
+            c => Result.failExit(c),
+            v => Result.doneExit(v)
+          )
+        )
+      )
   }
 
   final class ProvideSomeLayer[R0, -R, +E, +A](private val self: ZQuery[R, E, A]) extends AnyVal {
@@ -1779,14 +1792,16 @@ object ZQuery {
           query.step.raceWith[R, Nothing, Nothing, B1, Result[R, E, B1]](fiber.join)(
             (leftExit, rightFiber) =>
               leftExit.foldExitZIO(
-                cause => rightFiber.interrupt *> Exit.succeed(Result.fail(cause)),
+                cause => rightFiber.interrupt *> Result.failExit(cause),
                 {
                   case Result.Blocked(blockedRequests, Continue.Effect(query)) =>
-                    Exit.succeed(Result.blocked(blockedRequests, Continue.effect(race(query, fiber))))
+                    Result.blockedExit(blockedRequests, Continue.effect(race(query, fiber)))
                   case Result.Blocked(blockedRequests, Continue.Get(io)) =>
-                    Exit.succeed(Result.blocked(blockedRequests, Continue.effect(race(ZQuery.fromZIONow(io), fiber))))
-                  case Result.Done(value) => rightFiber.interrupt *> Exit.succeed(Result.done(value))
-                  case Result.Fail(cause) => rightFiber.interrupt *> Exit.succeed(Result.fail(cause))
+                    Result.blockedExit(blockedRequests, Continue.effect(race(ZQuery.fromZIONow(io), fiber)))
+                  case Result.Done(value) =>
+                    rightFiber.interrupt *> Result.doneExit(value)
+                  case Result.Fail(cause) =>
+                    rightFiber.interrupt *> Result.failExit(cause)
                 }
               ),
             (rightExit, leftFiber) => leftFiber.interrupt *> Exit.succeed(Result.fromExit(rightExit))
@@ -1801,7 +1816,7 @@ object ZQuery {
     def apply[A](
       f: R => A
     )(implicit tag: Tag[R], trace: Trace): ZQuery[R, Nothing, A] =
-      service[R].map(f)
+      ZQuery(ZIO.serviceWith[R](s => Result.done(f(s))))
   }
 
   final class ServiceWithQueryPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
@@ -1815,7 +1830,14 @@ object ZQuery {
     def apply[R <: Service, E, A](
       f: Service => ZIO[R, E, A]
     )(implicit tag: Tag[Service], trace: Trace): ZQuery[R with Service, E, A] =
-      service[Service].mapZIO(f)
+      ZQuery(
+        ZIO.serviceWithZIO[Service](
+          f(_).foldCauseZIO(
+            c => Result.failExit(c),
+            v => Result.doneExit(v)
+          )
+        )
+      )
   }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
+++ b/zio-query/shared/src/main/scala/zio/query/ZQuery.scala
@@ -22,6 +22,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.compat.{BuildFrom => _, _}
+import scala.collection.mutable.ArrayBuilder
 import scala.reflect.ClassTag
 
 /**
@@ -1160,16 +1161,7 @@ object ZQuery {
   )(
     f: A => ZQuery[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    as.sizeCompare(1) match {
-      case -1 => ZQuery.succeedNow(bf.newBuilder(as).result())
-      case 0  => f(as.head).map(v => (bf.newBuilder(as) += v).result())
-      case _ =>
-        ZQuery {
-          ZIO
-            .foreach[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
-            .map(collectResults(as, _, mode = 0))
-        }
-    }
+    foreachSequentialOuter(as, mode = 0)(f)
 
   /**
    * Applies the function `f` to each element of the `Set[A]` and returns the
@@ -1238,16 +1230,7 @@ object ZQuery {
   )(
     f: A => ZQuery[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
-    as.sizeCompare(1) match {
-      case -1 => ZQuery.succeedNow(bf.newBuilder(as).result())
-      case 0  => f(as.head).map(v => (bf.newBuilder(as) += v).result())
-      case _ =>
-        ZQuery {
-          ZIO
-            .foreach[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
-            .map(collectResults(as, _, mode = 2))
-        }
-    }
+    foreachSequentialOuter(as, mode = 2)(f)
 
   def foreachBatched[R, E, A, B](as: Set[A])(fn: A => ZQuery[R, E, B])(implicit
     trace: Trace
@@ -1307,107 +1290,9 @@ object ZQuery {
         ZQuery {
           ZIO
             .foreachPar[R, Nothing, A, Result[R, E, B], Iterable](as)(f(_).step)
-            .map(collectResults(as, _, mode = 1))
+            .map(v => collectResults(as, v.toArray, mode = 1).map(bf.fromSpecific(as)(_)))
         }
     }
-
-  private def collectResults[R, E, A, B, Collection[+Element] <: Iterable[Element]](
-    as: Collection[A],
-    results: Iterable[Result[R, E, B]],
-    mode: Int // 0 = sequential, 1 = parallel, 2 = batched
-  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): Result[R, E, Collection[B]] = {
-
-    def addToArray(array: Array[B])(idxs: Chunk[Int], values: Chunk[B]): Unit =
-      if (idxs.nonEmpty) {
-        var i       = 0
-        val iter    = values.chunkIterator
-        val idxIter = idxs.chunkIterator
-        while (idxIter.hasNextAt(i)) {
-          val idx   = idxIter.nextAt(i)
-          val value = iter.nextAt(i)
-          array(idx) = value
-          i += 1
-        }
-      }
-
-    var blockedRequests: BlockedRequests[R]          = BlockedRequests.empty
-    val doneBuilder: ChunkBuilder[B]                 = ChunkBuilder.make[B]()
-    val doneIndicesBuilder                           = new ChunkBuilder.Int
-    val effectBuilder: ChunkBuilder[ZQuery[R, E, B]] = ChunkBuilder.make[ZQuery[R, E, B]]()
-    val effectIndicesBuilder                         = new ChunkBuilder.Int
-    val failBuilder: ChunkBuilder[Cause[E]]          = ChunkBuilder.make[Cause[E]]()
-    val getBuilder                                   = ChunkBuilder.make[ZIO[R, E, B]]()
-    val getIndicesBuilder                            = new ChunkBuilder.Int
-    var index: Int                                   = 0
-    val iter                                         = results.iterator
-
-    while (iter.hasNext) {
-      iter.next() match {
-        case Result.Blocked(br, continue) =>
-          if (!br.isEmpty) {
-            blockedRequests = if (mode == 0) blockedRequests ++ br else blockedRequests && br
-          }
-          continue match {
-            case Continue.Effect(query) =>
-              effectBuilder.addOne(query)
-              effectIndicesBuilder.addOne(index)
-            case Continue.Get(io) =>
-              getBuilder.addOne(io)
-              getIndicesBuilder.addOne(index)
-          }
-          index += 1
-        case Result.Done(b) =>
-          doneBuilder.addOne(b)
-          doneIndicesBuilder.addOne(index)
-          index += 1
-        case Result.Fail(e) =>
-          failBuilder.addOne(e)
-          index += 1
-      }
-    }
-
-    val dones         = doneBuilder.result()
-    val doneIndices   = doneIndicesBuilder.result()
-    val effects       = effectBuilder.result()
-    val effectIndices = effectIndicesBuilder.result()
-    val gets          = getBuilder.result()
-    val getIndices    = getIndicesBuilder.result()
-    val fails         = failBuilder.result()
-    val size          = index // Store in a val to avoid boxing of var when used in the functions below
-
-    if (gets.isEmpty && effects.isEmpty && fails.isEmpty)
-      Result.done(bf.fromSpecific(as)(dones))
-    else if (fails.isEmpty) {
-      val continue =
-        if (effects.isEmpty) {
-          val io = ZIO.collectAll(gets).map { gets =>
-            val array = Array.ofDim[B](size)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]])
-            addToArray(array)(getIndices, gets)
-            addToArray(array)(doneIndices, dones)
-            bf.fromSpecific(as)(array)
-          }
-          Continue.get(io)
-        } else {
-          val collect = mode match {
-            case 0 => ZQuery.collectAll(effects)
-            case 1 => ZQuery.collectAllPar(effects)
-            case 2 => ZQuery.collectAllBatched(effects)
-          }
-          val query = collect.mapZIO { effects =>
-            ZIO.collectAll(gets).map { gets =>
-              val array = Array.ofDim[B](size)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]])
-              addToArray(array)(effectIndices, effects)
-              addToArray(array)(getIndices, gets)
-              addToArray(array)(doneIndices, dones)
-              bf.fromSpecific(as)(array)
-            }
-          }
-          Continue.effect(query)
-        }
-      Result.blocked(blockedRequests, continue)
-    } else
-      Result.fail(fails.foldLeft[Cause[E]](Cause.empty)(_ && _))
-  }
 
   /**
    * Performs a query for each element in a Set, collecting the results into a
@@ -1540,8 +1425,8 @@ object ZQuery {
     ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
-        case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
-      }.map(collectResults(as, _, mode = 2))
+        case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
+      }.map(v => collectResults(as, v, mode = 2).map(Chunk.fromArray))
     }
 
   /**
@@ -1556,8 +1441,8 @@ object ZQuery {
     ZQuery {
       ZQuery.currentCache.getWith {
         case Some(cache) => CachedResult.foreach(as)(r => cachedResult(cache, dataSource, f(r)))
-        case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r)))
-      }.map(collectResults(as, _, mode = 2))
+        case _           => ZIO.foreach(as)(r => uncachedResult(dataSource, f(r))).map(_.toArray)
+      }.map(v => collectResults(as, v, mode = 2).map(_.toList))
     }
 
   private def cachedResult[R, E, A, B](
@@ -1937,6 +1822,155 @@ object ZQuery {
       }
   }
 
+  private def foreachSequentialOuter[R, E, A, B, Collection[+Element] <: Iterable[Element]](
+    as: Collection[A],
+    mode: Int // 0 or 2
+  )(
+    f: A => ZQuery[R, E, B]
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZQuery[R, E, Collection[B]] =
+    as.sizeCompare(1) match {
+      case -1 => ZQuery.succeedNow(bf.fromSpecific(as)(Chunk.empty))
+      case 0  => f(as.head).map(v => bf.fromSpecific(as)(Chunk.single(v)))
+      case _ =>
+        ZQuery {
+          ZIO.suspendSucceed {
+            val arr = new ArrayBuilder.ofRef[Result[R, E, B]]
+            val ks  = as.knownSize
+            if (ks > 0) arr.sizeHint(ks)
+            val it = as.iterator
+
+            ZIO.whileLoop(it.hasNext)(f(it.next()).step)(arr.addOne).as {
+              collectResults(as, arr.result(), mode).map(bf.fromSpecific(as)(_))
+            }
+          }
+        }
+    }
+
+  @inline private def collectArrayZIO[R, E, A: ClassTag](
+    in: Array[ZIO[R, E, A]]
+  )(implicit trace: Trace): ZIO[R, E, Array[A]] = {
+    val iterator = in.iterator
+    val out      = Array.ofDim[A](in.length)
+    val size     = in.length
+    var i        = 0
+
+    ZIO.whileLoop(i < size)(in(i)) { v => out(i); i += 1 }.as(out)
+  }
+
+  private def collectResults[R, E, A, B, Collection[+Element] <: Iterable[Element]](
+    as: Collection[A],
+    results: Array[Result[R, E, B]],
+    mode: Int // 0 = sequential, 1 = parallel, 2 = batched
+  )(implicit trace: Trace): Result[R, E, Array[B]] = {
+    implicit val classTag: ClassTag[B] = ClassTag.AnyRef.asInstanceOf[ClassTag[B]]
+
+    @inline def addToArray(array: Array[B])(idxs: Array[Int], values: Array[B]): Unit = {
+      var i = 0
+      while (i < idxs.length) {
+        val idx   = idxs(i)
+        val value = values(i)
+        array(idx) = value
+        i += 1
+      }
+    }
+
+    var i                             = 0
+    val size                          = results.length
+    var doneSize, effectSize, getSize = 0
+
+    // 2-pass to pre-size arrays. Benchmarks show that this is faster than a single-pass using unsized builders
+    while (i < size) {
+      val n = results(i)
+      if (n.isInstanceOf[Result.Blocked[?, ?, ?]]) {
+        val continue = n.asInstanceOf[Result.Blocked[?, ?, ?]].continue
+        if (continue.isInstanceOf[Continue.Effect[?, ?, ?]])
+          effectSize += 1
+        else
+          getSize += 1
+      } else if (n.isInstanceOf[Result.Done[?]]) {
+        doneSize += 1
+      }
+      i += 1
+    }
+
+    var blockedRequests: BlockedRequests[R] = BlockedRequests.empty
+
+    val dones         = Array.ofDim[B](doneSize)
+    val doneIndices   = Array.ofDim[Int](doneSize)
+    val effects       = Array.ofDim[ZQuery[R, E, B]](effectSize)
+    val effectIndices = Array.ofDim[Int](effectSize)
+    val gets          = Array.ofDim[ZIO[R, E, B]](getSize)
+    val getIndices    = Array.ofDim[Int](getSize)
+
+    val failBuilder = new ArrayBuilder.ofRef[Cause[E]]
+
+    var eIdx, gIdx, dIdx, index = 0
+    val brEmpty                 = BlockedRequests.Empty
+
+    while (index < size) {
+      results(index) match {
+        case Result.Blocked(br, continue) =>
+          if (br ne brEmpty) {
+            blockedRequests = if (mode == 0) blockedRequests ++ br else blockedRequests && br
+          }
+          continue match {
+            case Continue.Effect(query) =>
+              effects(eIdx) = query
+              effectIndices(eIdx) = index
+              eIdx += 1
+            case Continue.Get(io) =>
+              gets(gIdx) = io
+              getIndices(gIdx) = index
+              gIdx += 1
+          }
+          index += 1
+        case Result.Done(b) =>
+          dones(dIdx) = b
+          doneIndices(dIdx) = index
+          gIdx += 1
+          index += 1
+        case Result.Fail(e) =>
+          failBuilder.addOne(e)
+          index += 1
+      }
+    }
+
+    val fails = failBuilder.result()
+
+    if (gets.isEmpty && effects.isEmpty && fails.isEmpty)
+      Result.done(dones)
+    else if (fails.isEmpty) {
+      val continue =
+        if (effects.isEmpty) {
+          val io = collectArrayZIO(gets).map { gets =>
+            val array = Array.ofDim[B](size)
+            addToArray(array)(getIndices, gets)
+            addToArray(array)(doneIndices, dones)
+            array
+          }
+          Continue.get(io)
+        } else {
+          val collect = mode match {
+            case 0 => ZQuery.collectAll(effects)
+            case 1 => ZQuery.collectAllPar(effects)
+            case 2 => ZQuery.collectAllBatched(effects)
+          }
+          val query = collect.mapZIO { effects =>
+            collectArrayZIO(gets).map { gets =>
+              val array = Array.ofDim[B](size)
+              addToArray(array)(effectIndices, effects)
+              addToArray(array)(getIndices, gets)
+              addToArray(array)(doneIndices, dones)
+              array
+            }
+          }
+          Continue.effect(query)
+        }
+      Result.blocked(blockedRequests, continue)
+    } else
+      Result.fail(fails.foldLeft[Cause[E]](Cause.empty)(_ && _))
+  }
+
   /**
    * The `CachedResult` represents a cache entry that can either be extracted
    * purely, or that it requires an effect to be run to obtain the result.
@@ -1958,59 +1992,65 @@ object ZQuery {
     )(
       f: A => CachedResult[R, E, B]
     )(implicit
-      trace: Trace,
-      bf: BuildFrom[Collection[A], Result[R, E, B], Collection[Result[R, E, B]]]
-    ): UIO[Collection[Result[R, E, B]]] =
-      ZIO.suspendSucceed {
-        val puresB  = bf.newBuilder(as)
-        val pureIdx = new ChunkBuilder.Int
+      trace: Trace
+    ): UIO[Array[Result[R, E, B]]] = {
+      val puresB  = Array.newBuilder[Result[R, E, B]]
+      val pureIdx = new ArrayBuilder.ofInt
 
-        val effectfulB   = Chunk.newBuilder[UIO[Result[R, E, B]]]
-        val effectfulIdx = new ChunkBuilder.Int
+      val effectfulB   = new ArrayBuilder.ofRef[UIO[Result[R, E, B]]]
+      val effectfulIdx = new ArrayBuilder.ofInt
 
-        val iter = as.iterator
-        var i    = 0
-        while (iter.hasNext) {
-          val next = f(iter.next())
-          next match {
-            case Pure(result) =>
-              puresB += result
-              pureIdx.addOne(i)
-            case Effectful(io) =>
-              effectfulB += io
-              effectfulIdx.addOne(i)
-          }
-          i += 1
+      val iter = as.iterator
+      var i    = 0
+      while (iter.hasNext) {
+        val next = f(iter.next())
+        next match {
+          case Pure(result) =>
+            puresB.addOne(result)
+            pureIdx.addOne(i)
+          case Effectful(io) =>
+            effectfulB.addOne(io)
+            effectfulIdx.addOne(i)
         }
+        i += 1
+      }
 
-        val pures     = puresB.result()
-        val effectful = effectfulB.result()
+      val pures     = puresB.result()
+      val effectful = effectfulB.result()
 
-        if (effectful.isEmpty) Exit.succeed(pures)
-        else if (pures.isEmpty) ZIO.collectAll(effectful).map(bf.fromSpecific(as))
-        else {
-          val pIdxs = pureIdx.result()
-          val eIdxs = effectfulIdx.result()
+      if (effectful.isEmpty) Exit.succeed(pures)
+      else if (pures.isEmpty) collectArrayZIO(effectful)
+      else {
+        val pIdxs = pureIdx.result()
+        val eIdxs = effectfulIdx.result()
 
-          ZIO.collectAll(effectful).map { effectful =>
-            val arr = Array.ofDim[Result[R, E, B]](pIdxs.size + eIdxs.size)
+        collectArrayZIO(effectful).map { effectful =>
+          val arr = Array.ofDim[Result[R, E, B]](pIdxs.length + eIdxs.length)
 
-            def addToArray(idxs: Chunk[Int], values: Iterable[Result[R, E, B]]): Unit = {
-              val iter    = values.iterator
-              val idxIter = idxs.iterator
-              while (idxIter.hasNext) {
-                val idx   = idxIter.next()
-                val value = iter.next()
-                arr(idx) = value
-              }
+          def addToArray(idxs: Array[Int], values: Array[Result[R, E, B]]): Unit = {
+            var i = 0
+            while (i < idxs.length) {
+              val idx   = idxs(i)
+              val value = values(i)
+              arr(idx) = value
+              i += 1
             }
-
-            addToArray(pIdxs, pures)
-            addToArray(eIdxs, effectful)
-            bf.fromSpecific(as)(arr)
           }
+
+          addToArray(pIdxs, pures)
+          addToArray(eIdxs, effectful)
+          arr
         }
       }
+    }
   }
 
+  // Patches for Scala 2.12
+  private implicit class ArrBuilderOps[A](private val builder: ArrayBuilder[A]) extends AnyVal {
+    def addOne(value: A): Unit = builder += value
+  }
+
+  private implicit class IterableOps[A](private val it: Iterable[A]) extends AnyVal {
+    def knownSize: Int = it.size
+  }
 }

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -104,6 +104,17 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
     }
 
   /**
+   * Effectually maps over the success type of this continuation.
+   */
+  final def mapZIO[R1 <: R, E1 >: E, B](
+    f: A => ZIO[R1, E1, B]
+  )(implicit trace: Trace): Continue[R1, E1, B] =
+    self match {
+      case Effect(query) => effect(query.mapZIO(f))
+      case Get(io)       => get(io.flatMap(f))
+    }
+
+  /**
    * Purely contramaps over the environment type of this continuation.
    */
   final def provideSomeEnvironment[R0](
@@ -111,7 +122,7 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
   )(implicit trace: Trace): Continue[R0, E, A] =
     self match {
       case Effect(query) => effect(query.provideSomeEnvironment(f))
-      case Get(io)       => get(io)
+      case Get(io)       => get(io.asInstanceOf[ZIO[R0, E, A]])
     }
 
   /**
@@ -176,9 +187,9 @@ private[query] object Continue {
    * Constructs a continuation that merely gets the result of a blocked request
    * (potentially transforming it with pure functions).
    */
-  def get[E, A](io: IO[E, A]): Continue[Any, E, A] =
+  def get[R, E, A](io: ZIO[R, E, A]): Continue[R, E, A] =
     Get(io)
 
   final case class Effect[R, E, A](query: ZQuery[R, E, A]) extends Continue[R, E, A]
-  final case class Get[E, A](io: IO[E, A])                 extends Continue[Any, E, A]
+  final case class Get[R, E, A](io: ZIO[R, E, A])          extends Continue[R, E, A]
 }

--- a/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Continue.scala
@@ -122,7 +122,7 @@ private[query] sealed trait Continue[-R, +E, +A] { self =>
   )(implicit trace: Trace): Continue[R0, E, A] =
     self match {
       case Effect(query) => effect(query.provideSomeEnvironment(f))
-      case Get(io)       => get(io.asInstanceOf[ZIO[R0, E, A]])
+      case Get(io)       => get(io.provideSomeEnvironment(f.value))
     }
 
   /**

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -108,38 +108,41 @@ private[query] object Result {
    * Constructs a result that is blocked on the specified requests with the
    * specified continuation.
    */
-  def blocked[R, E, A](blockedRequests: BlockedRequests[R], continue: Continue[R, E, A]): Blocked[R, E, A] =
+  def blocked[R, E, A](blockedRequests: BlockedRequests[R], continue: Continue[R, E, A]): Result[R, E, A] =
     Blocked(blockedRequests, continue)
 
   def blockedExit[R, E, A](
     blockedRequests: BlockedRequests[R],
     continue: Continue[R, E, A]
-  ): Exit.Success[Blocked[R, E, A]] =
+  ): Exit[Nothing, Result[R, E, A]] =
     Exit.Success(Blocked(blockedRequests, continue))
 
   /**
    * Constructs a result that is done with the specified value.
    */
-  def done[A](value: A): Done[A] =
+  def done[A](value: A): Result[Any, Nothing, A] =
     Done(value)
 
-  def doneExit[A](value: A): Exit.Success[Done[A]] =
+  def doneExit[A](value: A): Exit[Nothing, Result[Any, Nothing, A]] =
     Exit.Success(Done(value))
 
   /**
    * Constructs a result that is failed with the specified `Cause`.
    */
-  def fail[E](cause: Cause[E]): Fail[E] =
+  def fail[E](cause: Cause[E]): Result[Any, E, Nothing] =
     Fail(cause)
 
-  def failExit[E](cause: Cause[E]): Exit.Success[Fail[E]] =
+  def failExit[E](cause: Cause[E]): Exit[Nothing, Result[Any, E, Nothing]] =
     Exit.Success(Fail(cause))
 
   /**
    * Lifts an `Exit` into a result.
    */
   def fromExit[E, A](exit: Exit[E, A]): Result[Any, E, A] =
-    exit.foldExit(Result.fail, Result.done)
+    exit match {
+      case Exit.Success(a) => Done(a)
+      case Exit.Failure(e) => Fail(e)
+    }
 
   val unit: Result[Any, Nothing, Unit] = done(())
 

--- a/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
+++ b/zio-query/shared/src/main/scala/zio/query/internal/Result.scala
@@ -108,20 +108,32 @@ private[query] object Result {
    * Constructs a result that is blocked on the specified requests with the
    * specified continuation.
    */
-  def blocked[R, E, A](blockedRequests: BlockedRequests[R], continue: Continue[R, E, A]): Result[R, E, A] =
+  def blocked[R, E, A](blockedRequests: BlockedRequests[R], continue: Continue[R, E, A]): Blocked[R, E, A] =
     Blocked(blockedRequests, continue)
+
+  def blockedExit[R, E, A](
+    blockedRequests: BlockedRequests[R],
+    continue: Continue[R, E, A]
+  ): Exit.Success[Blocked[R, E, A]] =
+    Exit.Success(Blocked(blockedRequests, continue))
 
   /**
    * Constructs a result that is done with the specified value.
    */
-  def done[A](value: A): Result[Any, Nothing, A] =
+  def done[A](value: A): Done[A] =
     Done(value)
+
+  def doneExit[A](value: A): Exit.Success[Done[A]] =
+    Exit.Success(Done(value))
 
   /**
    * Constructs a result that is failed with the specified `Cause`.
    */
-  def fail[E](cause: Cause[E]): Result[Any, E, Nothing] =
+  def fail[E](cause: Cause[E]): Fail[E] =
     Fail(cause)
+
+  def failExit[E](cause: Cause[E]): Exit.Success[Fail[E]] =
+    Exit.Success(Fail(cause))
 
   /**
    * Lifts an `Exit` into a result.


### PR DESCRIPTION
This PR rewrites the method which is responsible for partitioning a collection of `ZQuery`. There are 2 notable changes in this PR:
1. We avoid unnecessary lifting of ZIO to ZQuery when we map a `Continue.Get`
2. We avoid unnecessary conversions between different iterable types by having the internal methods use Arrays only.

With the above, we see ~30% improvement in throughput across the `FromRequestBenchmark` suite

Note that in order to make things a bit safer, I also added the `Mode` type-alias and an assertion for a method that the Mode cannot be Parallel. In order to remove the runtime overhead of the assertion, I adopted a similar approach to ZIO where the assertion disappears in the published artifacts