### PR TITLE
CI: Drop JDK 11, add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,9 @@ jobs:
       fail-fast: false
       matrix:
         java:
-        - '11'
+        - '17'
         - '21'
+        - '25'
         scala-project:
         - ++2.12 zioQueryJVM
         - ++2.13 zioQueryJVM


### PR DESCRIPTION
## Summary
- Drop JDK 11 from the CI test matrix
- Add JDK 17 and JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25